### PR TITLE
Type annotations for generated patterns + fix empty patterns

### DIFF
--- a/src/Data/Record/QQ/CodeGen.hs
+++ b/src/Data/Record/QQ/CodeGen.hs
@@ -184,9 +184,10 @@ deconstruct = \pat -> do
                    case mapMaybe getPat recordInfoFields of
                      [] -> wildP
                      fieldPats ->
-                       viewP (varE 'matchHasField) $
-                         mkTupleP (uncurry mkPat) $
-                           nest (MaxTupleElems 2) fieldPats
+                       parensP $
+                         viewP (varE 'matchHasField) $
+                           mkTupleP (uncurry mkPat) $
+                             nest (MaxTupleElems 2) fieldPats
                  partialType = foldl appT (conT (N.toName recordInfoUnqual)) [wildCardT | _ <- recordInfoTVars]
               in runQ $ sigP recordPat partialType
                   


### PR DESCRIPTION
### 1. Type annotations for generated patterns

Right now `large-records` generates only view patterns for fields, and ignores constructor name and type, so it is a valid code

```haskell
largeRecord defaultPureScript [d|
  data A = A {a :: Int}
  data B = B {a :: String} |]

-- inferred type
-- f :: HasField "a" a1 a2 => a1 -> a2
f [lr| A{a} |] = a

g :: Int
g = f [lr| A{a = 42} |]

h :: String
h = f [lr| B{a = "hello"} |]
```

There are two problems here:
1. There are no type inference via constructor
2. It is possible to send another record with some of same fields

So we need to annotate patterns with type of record. Like this:
```haskell
largeRecord defaultPureScript [d|
  data A = A {a :: Int} |]

-- inferred type
-- f :: A -> Int
f [lr| A { a } |] = a
-- ->
f ((matchHasField -> fieldNamed @"a" -> a) :: X) = a
```

But it is impossible (easily) to annotate patterns with correct type with parameters, because code generation is done before typecheking, so we can't insert full type annotation here
```haskell
largeRecord defaultPureScript [d|
  data A (a :: Type) = A {a :: a} |]

g [lr|A{a = True}|] = "hello" -- `A ?`
```

But we can use `PartialTypeSignatures` and generate such pattern
```haskell
largeRecord defaultPureScript [d|
  data A (a :: Type) = A {a :: a} |]

-- inferred type
-- g :: A Bool -> [Char]
g [lr|A{a = True}|] = "hello"
-- ->
g ((matchHasField -> fieldNamed @"a" -> True) :: A _) = "hello"

-- inferred type
-- h :: A _ -> _
h [lr|A{a}|] = a
-- ->
h ((matchHasField -> fieldNamed @"a" -> a) :: A _) = a
```

### 2. Fix empty patterns
Right now `large-records` fails on patterns like this
```haskell
-- inferred type
-- f :: MatchHasField a () => a -> [Char]
f [lr| A{} |] = 42
-- -> f (matchHasField -> ()) = "hello"

h = f [lr| X{ a = 42} |]

-- No instance for (Data.Record.QQ.Runtime.MatchHasField.MatchHasField X ()) 
```

And I don't know how to write instance `MatchHasField r ()` because of fundep
```haskell
class MatchHasField a b | b -> a where
```

So my solution is to generate wildcard pattern on empty fields list
```haskell
-- inferred type
-- f :: X -> [Char]
f [lr| X{} |] = "hello"
-- -> f (_ :: X) = "hello"
```