### PR TITLE
Kana/type annotations for pattens

### DIFF
--- a/large-records.cabal
+++ b/large-records.cabal
@@ -134,6 +134,7 @@ test-suite test-large-records
                        -Wincomplete-record-updates
                        -Wpartial-fields
                        -Widentities
+                       -Wno-partial-type-signatures
                        -ddump-to-file
                        -- Needed for the AllZip tests
                        -freduction-depth=2000

--- a/src/Data/Record/QQ/CodeGen.hs
+++ b/src/Data/Record/QQ/CodeGen.hs
@@ -184,9 +184,10 @@ deconstruct = \pat -> do
                    case mapMaybe getPat recordInfoFields of
                      [] -> wildP
                      fieldPats ->
-                       viewP (varE 'matchHasField) $
-                         mkTupleP (uncurry mkPat) $
-                           nest (MaxTupleElems 2) fieldPats
+                       parensP $
+                         viewP (varE 'matchHasField) $
+                           mkTupleP (uncurry mkPat) $
+                             nest (MaxTupleElems 2) fieldPats
                  partialType = foldl appT (conT (N.toName recordInfoUnqual)) [wildCardT | _ <- recordInfoTVars]
               in runQ $ sigP recordPat partialType
                   

--- a/src/Data/Record/QQ/CodeGen.hs
+++ b/src/Data/Record/QQ/CodeGen.hs
@@ -182,14 +182,13 @@ deconstruct = \pat -> do
            Just (ParsedRecordInfo RecordInfo{..}) ->
              let recordPat =
                    case mapMaybe getPat recordInfoFields of
-                     [] -> wildP
+                     [] -> bangP wildP
                      fieldPats ->
-                       parensP $
-                         viewP (varE 'matchHasField) $
-                           mkTupleP (uncurry mkPat) $
-                             nest (MaxTupleElems 2) fieldPats
+                       viewP (varE 'matchHasField) $
+                         mkTupleP (uncurry mkPat) $
+                           nest (MaxTupleElems 2) fieldPats
                  partialType = foldl appT (conT (N.toName recordInfoUnqual)) [wildCardT | _ <- recordInfoTVars]
-              in runQ $ sigP recordPat partialType
+              in runQ $ sigP (parensP recordPat) partialType
                   
 
     getPat :: FieldInfo Pat -> Maybe (N.OverloadedName, Pat)

--- a/src/Data/Record/QQ/CodeGen/HSE.hs
+++ b/src/Data/Record/QQ/CodeGen/HSE.hs
@@ -32,6 +32,7 @@ extensionFromTH = \case
     TH.RecordPuns       -> EnableExtension $ NamedFieldPuns
     TH.TypeApplications -> EnableExtension $ TypeApplications
     TH.ViewPatterns     -> EnableExtension $ ViewPatterns
+    TH.BlockArguments   -> EnableExtension $ BlockArguments
 
     -- We don't care about all extensions; there are many of them, and they vary
     -- from ghc version to ghc version. Treating them all would be a lot of work

--- a/src/Data/Record/QQ/CodeGen/HSE.hs
+++ b/src/Data/Record/QQ/CodeGen/HSE.hs
@@ -32,7 +32,6 @@ extensionFromTH = \case
     TH.RecordPuns       -> EnableExtension $ NamedFieldPuns
     TH.TypeApplications -> EnableExtension $ TypeApplications
     TH.ViewPatterns     -> EnableExtension $ ViewPatterns
-    TH.BlockArguments   -> EnableExtension $ BlockArguments
 
     -- We don't care about all extensions; there are many of them, and they vary
     -- from ghc version to ghc version. Treating them all would be a lot of work

--- a/src/Data/Record/TH/CodeGen.hs
+++ b/src/Data/Record/TH/CodeGen.hs
@@ -600,7 +600,7 @@ genMetadata Options{..} RecordDef{..} = do
 --
 -- TODO: Think about DeriveFunctor?
 genDeriving :: Options -> RecordDef -> Deriving -> Q Dec
-genDeriving opts r@RecordDef{..} = \case
+genDeriving opts r = \case
     DeriveEq    -> inst ''Eq   '(==)      'geq
     DeriveOrd   -> inst ''Ord  'compare   'gcompare
     DeriveShow  -> inst ''Show 'showsPrec 'gshowsPrec

--- a/test/Test/Record/Sanity/HKD.hs
+++ b/test/Test/Record/Sanity/HKD.hs
@@ -10,6 +10,7 @@
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE UndecidableInstances  #-}
 {-# LANGUAGE ViewPatterns          #-}
+{-# LANGUAGE PartialTypeSignatures #-}
 
 {-# OPTIONS_GHC -F -pgmF=record-dot-preprocessor #-}
 -- {-# OPTIONS_GHC -ddump-splices #-}

--- a/test/Test/Record/Sanity/Lens/Micro.hs
+++ b/test/Test/Record/Sanity/Lens/Micro.hs
@@ -9,6 +9,7 @@
 {-# LANGUAGE TemplateHaskell       #-}
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE UndecidableInstances  #-}
+{-# LANGUAGE PartialTypeSignatures #-}
 
 {-# OPTIONS_GHC -Wno-missing-signatures #-}
 {-# LANGUAGE TypeApplications #-}

--- a/test/Test/Record/Sanity/PatternMatch.hs
+++ b/test/Test/Record/Sanity/PatternMatch.hs
@@ -14,6 +14,7 @@
 {-# LANGUAGE ViewPatterns          #-}
 {-# LANGUAGE PartialTypeSignatures #-}
 
+{-# OPTIONS_GHC -Wno-missing-signatures #-}
 -- {-# OPTIONS_GHC -ddump-splices #-}
 
 module Test.Record.Sanity.PatternMatch (tests) where
@@ -55,14 +56,21 @@ projectNested [lr| MkS { x = a, y = MkT { x = b, y = c } } |] = (a, b, c)
 projectView :: T Bool -> Int
 projectView [lr| MkT { x = ((+1) -> a) } |] = a
 
+matchEmpty :: T Bool -> Int
+matchEmpty [lr| MkT {} |] = 42
+
+matchEmptyNoSign [lr| MkT {} |] = 42 :: Int
+
 testProjections :: Assertion
 testProjections = do
-    assertEqual "one"    (projectOne    t)  5
-    assertEqual "two"    (projectTwo    t) (5, [True])
-    assertEqual "three"  (projectThree  t) (5, [True], 1.0)
-    assertEqual "puns"   (projectPuns   t) (5, [True])
-    assertEqual "nested" (projectNested s) ('a', 2, [True, False])
-    assertEqual "view"   (projectView   t)  6
+    assertEqual "one"           (projectOne       t)  5
+    assertEqual "two"           (projectTwo       t) (5, [True])
+    assertEqual "three"         (projectThree     t) (5, [True], 1.0)
+    assertEqual "puns"          (projectPuns      t) (5, [True])
+    assertEqual "nested"        (projectNested    s) ('a', 2, [True, False])
+    assertEqual "view"          (projectView      t)  6
+    assertEqual "empty"         (matchEmpty       t)  42
+    assertEqual "empty-no-sign" (matchEmptyNoSign t)  42
   where
     t :: T Bool
     t = [lr| MkT { x = 5, y = [True], z = 1.0 } |]

--- a/test/Test/Record/Sanity/PatternMatch.hs
+++ b/test/Test/Record/Sanity/PatternMatch.hs
@@ -12,6 +12,7 @@
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE UndecidableInstances  #-}
 {-# LANGUAGE ViewPatterns          #-}
+{-# LANGUAGE PartialTypeSignatures #-}
 
 -- {-# OPTIONS_GHC -ddump-splices #-}
 

--- a/test/Test/Record/Sanity/QualifiedImports.hs
+++ b/test/Test/Record/Sanity/QualifiedImports.hs
@@ -1,7 +1,9 @@
-{-# LANGUAGE DataKinds        #-}
-{-# LANGUAGE QuasiQuotes      #-}
-{-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE ViewPatterns     #-}
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE QuasiQuotes           #-}
+{-# LANGUAGE TypeApplications      #-}
+{-# LANGUAGE ViewPatterns          #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE PartialTypeSignatures #-}
 
 {-# OPTIONS_GHC -fplugin=RecordDotPreprocessor #-}
 

--- a/test/Test/Record/Util.hs
+++ b/test/Test/Record/Util.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE InstanceSigs               #-}
 {-# LANGUAGE TemplateHaskell            #-}
+{-# LANGUAGE CPP                        #-}
 
 module Test.Record.Util (
     -- * Tasty/HUnit auxiliary
@@ -121,6 +122,9 @@ instance Quasi CollectProblems where
   qLookupName         = \x y -> liftQ $ qLookupName         x y
   qReify              = \x   -> liftQ $ qReify              x
   qReifyFixity        = \x   -> liftQ $ qReifyFixity        x
+#if MIN_VERSION_template_haskell(2,16,0)
+  qReifyType          = \x   -> liftQ $ qReifyType          x
+#endif
   qReifyInstances     = \x y -> liftQ $ qReifyInstances     x y
   qReifyRoles         = \x   -> liftQ $ qReifyRoles         x
   qReifyAnnotations   = \x   -> liftQ $ qReifyAnnotations   x


### PR DESCRIPTION
### 1. Type annotations for generated patterns

Right now `large-records` generates only view patterns for fields, and ignores constructor name and type, so it is a valid code

```haskell
largeRecord defaultPureScript [d|
  data A = A {a :: Int}
  data B = B {a :: String} |]

-- inferred type
-- f :: HasField "a" a1 a2 => a1 -> a2
f [lr| A{a} |] = a

g :: Int
g = f [lr| A{a = 42} |]

h :: String
h = f [lr| B{a = "hello"} |]
```

There are two problems here:
1. There are no type inference via constructor
2. It is possible to send another record with some of same fields

So we need to annotate patterns with type of record. Like this:
```haskell
largeRecord defaultPureScript [d|
  data A = A {a :: Int} |]

-- inferred type
-- f :: A -> Int
f [lr| A { a } |] = a
-- ->
f ((matchHasField -> fieldNamed @"a" -> a) :: X) = a
```

But it is impossible (easily) to annotate patterns with correct type with parameters, because code generation is done before typecheking, so we can't insert full type annotation here
```haskell
largeRecord defaultPureScript [d|
  data A (a :: Type) = A {a :: a} |]

g [lr|A{a = True}|] = "hello" -- `A ?`
```

But we can use `PartialTypeSignatures` and generate such pattern
```haskell
largeRecord defaultPureScript [d|
  data A (a :: Type) = A {a :: a} |]

-- inferred type
-- g :: A Bool -> [Char]
g [lr|A{a = True}|] = "hello"
-- ->
g ((matchHasField -> fieldNamed @"a" -> True) :: A _) = "hello"

-- inferred type
-- h :: A _ -> _
h [lr|A{a}|] = a
-- ->
h ((matchHasField -> fieldNamed @"a" -> a) :: A _) = a
```

### 2. Fix empty patterns
Right now `large-records` fails on patterns like that
```haskell
-- inferred type
-- f :: MatchHasField a () => a -> [Char]
f [lr| A{} |] = 42
-- -> f (matchHasField -> ()) = "hello"

h = f [lr| X{ a = 42} |]

-- No instance for (Data.Record.QQ.Runtime.MatchHasField.MatchHasField X ()) 
```

And I don't know how to write instance `MatchHasField r ()` because of fundep
```haskell
class MatchHasField a b | b -> a where
```

So my solution is to generate strict wildcard pattern on empty fields list
```haskell
-- inferred type
-- f :: X -> [Char]
f [lr| X{} |] = "hello"
-- -> f ((!_) :: X) = "hello"
```

We need `BangPattern` here instead of pattern `X _ :: X` for example because generated constructor is newtype constructor and will not change anything, but we need strict behaviour from vanilla haskell records.

P.S.: also now `large-records` compiles both on ghc 8.8 and 8.10