### PR TITLE
Avoid type ambiguity, support empty patterns

### DIFF
--- a/src/Data/Record/Internal/CodeGen.hs
+++ b/src/Data/Record/Internal/CodeGen.hs
@@ -13,6 +13,7 @@ module Data.Record.Internal.CodeGen (
   , recordFromVectorDontForceE
   , recordIndexedAccessorE
   , recordIndexedOverwriteE
+  , recordUndefinedValueE
     -- * Fields
   , fieldNameE
   , fieldNameT
@@ -73,6 +74,10 @@ recordIndexedAccessorE qual =
 recordIndexedOverwriteE :: N.Qualifier -> Record a -> Q Exp
 recordIndexedOverwriteE qual =
     N.varE . N.qualify qual . nameRecordIndexedOverwrite . recordType
+
+recordUndefinedValueE :: N.Qualifier -> Record a -> Q Exp
+recordUndefinedValueE qual r =
+    [| $(recordFromVectorDontForceE qual r) undefined |]
 
 {-------------------------------------------------------------------------------
   Record fields

--- a/test/Test/Record/Sanity/PatternMatch.hs
+++ b/test/Test/Record/Sanity/PatternMatch.hs
@@ -13,19 +13,24 @@
 {-# LANGUAGE UndecidableInstances  #-}
 {-# LANGUAGE ViewPatterns          #-}
 
+{-# OPTIONS_GHC -Wno-missing-signatures #-}
+{-# OPTIONS_GHC -fdefer-type-errors -Wno-deferred-type-errors  #-}
 -- {-# OPTIONS_GHC -ddump-splices #-}
 
 module Test.Record.Sanity.PatternMatch (tests) where
 
+import Control.Exception
+import Data.List (isInfixOf)
 import Test.Tasty
 import Test.Tasty.HUnit
 
 import Data.Record.TH
 
-data R a = MkR { rInt :: Int,  rList :: [a] }
+import Test.Record.Util
 
-_projectPunsR :: R a -> (Int, [a])
-_projectPunsR MkR { rInt, rList } = (rInt, rList)
+{-------------------------------------------------------------------------------
+  Basic pattern matching tests
+-------------------------------------------------------------------------------}
 
 largeRecord defaultPureScript [d|
     data T a = MkT { x :: Int,  y :: [a], z :: Double }
@@ -54,6 +59,38 @@ projectNested [lr| MkS { x = a, y = MkT { x = b, y = c } } |] = (a, b, c)
 projectView :: T Bool -> Int
 projectView [lr| MkT { x = ((+1) -> a) } |] = a
 
+matchEmpty :: T Bool -> Int
+matchEmpty [lr| MkT {} |] = 42
+
+{-------------------------------------------------------------------------------
+  Verify inferred types
+
+  We want to infer that the types are not more polymorphic than they should be:
+  functions that match on a record should not be polymorphic in 'HasField', but
+  should only accept values of that specific record type.
+
+  Functions 'useNoSigEmpty' and 'useNoSigNonEmpty' below will have (deferred)
+  type errors iff 'noSigEmpty' and 'noSigNonEmpty' are suffciently monomorphic.
+-------------------------------------------------------------------------------}
+
+largeRecord defaultPureScript [d|
+    data T2 = MkT2 { x :: Int }
+  |]
+
+noSigEmpty [lr| MkT {} |] = ()
+
+noSigNonEmpty [lr| MkT { x = a } |] = const () a
+
+useNoSigEmpty :: ()
+useNoSigEmpty = noSigEmpty [lr| MkT2 { x = 5 } |]
+
+useNoSigNonEmpty :: ()
+useNoSigNonEmpty = noSigNonEmpty [lr| MkT2 { x = 5 } |]
+
+{-------------------------------------------------------------------------------
+  Tests proper
+-------------------------------------------------------------------------------}
+
 testProjections :: Assertion
 testProjections = do
     assertEqual "one"    (projectOne    t)  5
@@ -62,7 +99,16 @@ testProjections = do
     assertEqual "puns"   (projectPuns   t) (5, [True])
     assertEqual "nested" (projectNested s) ('a', 2, [True, False])
     assertEqual "view"   (projectView   t)  6
+    assertEqual "empty"  (matchEmpty    t)  42
+
+    expectException isExpectedTypeError $
+      assertEqual "sig-empty"    useNoSigEmpty    ()
+    expectException isExpectedTypeError $
+      assertEqual "sig-nonempty" useNoSigNonEmpty ()
   where
+    isExpectedTypeError :: SomeException -> Bool
+    isExpectedTypeError e = "Couldn't match expected type" `isInfixOf` show e
+
     t :: T Bool
     t = [lr| MkT { x = 5, y = [True], z = 1.0 } |]
 

--- a/test/Test/Record/Sanity/QualifiedImports.hs
+++ b/test/Test/Record/Sanity/QualifiedImports.hs
@@ -1,7 +1,8 @@
-{-# LANGUAGE DataKinds        #-}
-{-# LANGUAGE QuasiQuotes      #-}
-{-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE ViewPatterns     #-}
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE QuasiQuotes           #-}
+{-# LANGUAGE TypeApplications      #-}
+{-# LANGUAGE ViewPatterns          #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
 
 {-# OPTIONS_GHC -fplugin=RecordDotPreprocessor #-}
 -- {-# OPTIONS_GHC -ddump-splices #-}


### PR DESCRIPTION
In #18 , @kana-sama rightfully points out that the current code generation for pattern matching results in types that are too polymorphic. A function such as

```haskell
foo [lr| MkT { x = a } |] = const () a
```

might get an inferred type

```haskell
foo :: forall r. HasField "x" r a => ..
```

This may lead to confusing error messages, and worse, it would make it possible to apply `foo` to an argument of a completely different record type.

#18 also adds support for empty record matches. 

The main disadvantage of #18 was that it relied on partial type signatures; requiring users to enable partial signatures in modules that use `large-records` and disable the corresponding ghc warning is a bit unfortunate. This PR supersedes #18 by resolving the problem in a slightly different way: instead of giving a type signature, we rely on

```haskell
viewAtType :: a -> a -> a
viewAtType = const id
```

Example use:

```haskell
foo (viewAtType (LR__MkT undefined) -> matchHasField -> fieldNamed @"x" -> a) = a
```

Fixing the problem in this way was by no means easy, because there was not enough sharing in the library as it stood between the TH code generation and the QQ code generation; this PR was only possible (and reasonable easy) after #20, #21, #22 and #23.

In addition to this change in approach, this PR also is different from #18 in a few other ways:

- The tests are a bit stronger: we actually verify that the inferred type is not too polymorphic.
- The bang pattern on the empty pattern match is not used. After the aforementioned refactoring, it is much more obvious when we are and aren't matching on a large record; pattern matches on vanilla Haskell records are left alone, and matches on large records are by definition matches on newtypes, so the bang does not do anything.