### PR TITLE
Remove library dependency on micro-lens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Revision history for large-records
 
+## Unreleased
+
+* Removed library dependency on micro-lens
+* Rename module Data.Record.Lens.Micro -> Data.Record.Lens.VL
+
 ## 0.1.0.0 -- 2021-08-19
 
 * First public release

--- a/large-records.cabal
+++ b/large-records.cabal
@@ -26,7 +26,7 @@ library
                         Data.Record.Generic.Eq
                         Data.Record.Generic.GHC
                         Data.Record.Generic.JSON
-                        Data.Record.Generic.Lens.Micro
+                        Data.Record.Generic.Lens.VL
                         Data.Record.Generic.LowerBound
                         Data.Record.Generic.Rep
                         Data.Record.Generic.Rep.Internal
@@ -62,7 +62,6 @@ library
                       , generics-sop     >= 0.5    && < 0.6
                       , haskell-src-exts >= 1.21.1 && < 1.24
                       , haskell-src-meta >= 0.8.3  && < 0.9
-                      , microlens        >= 0.1.5  && < 0.5
                       , mtl              >= 2.2.1  && < 2.3
                       , record-hasfield  >= 1.0    && < 1.1
                       , sop-core         >= 0.5    && < 0.6

--- a/src/Data/Record/Generic/Lens/VL.hs
+++ b/src/Data/Record/Generic/Lens/VL.hs
@@ -9,7 +9,15 @@
 {-# LANGUAGE TypeOperators         #-}
 {-# LANGUAGE QuantifiedConstraints #-}
 
-module Data.Record.Generic.Lens.Micro (
+-- | van Laarhoven lenses for large records.
+-- The type synonym
+--
+-- @
+--   type Lens' s a = forall f. Functor f => (a -> f a) -> s -> f s
+-- @
+-- Appears below, however it is not exported to avoid conflicts with other
+-- libraries defining equivalent synonyms.
+module Data.Record.Generic.Lens.VL (
     -- * Lenses for records
     SimpleRecordLens(..)
   , HKRecordLens(..)
@@ -31,12 +39,14 @@ module Data.Record.Generic.Lens.Micro (
   ) where
 
 import Data.Kind
-import Lens.Micro (Lens')
 
 import Data.Record.Generic
 import Data.Record.Generic.Transform
 
 import qualified Data.Record.Generic.Rep as Rep
+
+-- | The standard van Laarhoven representation for a monomorphic lens
+type Lens' s a = forall f. Functor f => (a -> f a) -> s -> f s
 
 {-------------------------------------------------------------------------------
   Simple records (in contrast to higher-kinded records, see below)

--- a/test/Test/Record/Sanity/Lens/Micro.hs
+++ b/test/Test/Record/Sanity/Lens/Micro.hs
@@ -24,7 +24,7 @@ import Test.Tasty
 import Test.Tasty.HUnit
 
 import Data.Record.Generic
-import Data.Record.Generic.Lens.Micro
+import Data.Record.Generic.Lens.VL
 import Data.Record.Generic.SOP
 import Data.Record.Generic.Transform
 import Data.Record.QQ.CodeGen


### PR DESCRIPTION
Note that the name of the module no longer seems appropriate. I would
recommend it be changed to Data.Reocrd.Lens.

ref #26 