### PR TITLE
Make empty pattern match strict

### DIFF
--- a/src/Data/Record/QQ/CodeGen.hs
+++ b/src/Data/Record/QQ/CodeGen.hs
@@ -193,7 +193,7 @@ deconstruct = \pat -> do
                        recordUndefinedValueE UseQuasiQuoter qual r
                    ) $
                case recordFields (dropMissingRecordFields r) of
-                 [] -> wildP
+                 [] -> bangP wildP
                  fs -> outerViewPat fs
 
     outerViewPat :: [Field Pat] -> Q Pat


### PR DESCRIPTION
@kana-sama pointed this problem out in #18, but I had misunderstood the point. In addition to fixing the problem in the way that #18 had already done, this now also adds a test.