### PR TITLE
Allow `Constraints` to depend on both variables

### DIFF
--- a/src/Data/Record/Generic.hs
+++ b/src/Data/Record/Generic.hs
@@ -43,7 +43,7 @@ import qualified Data.Record.Generic.Rep.Internal as Rep
 
 class Generic a where
   -- | @Constraints a c@ means "all fields of @a@ satisfy @c@"
-  type Constraints a :: (Type -> Constraint) -> Constraint
+  type Constraints a (c :: Type -> Constraint) :: Constraint
 
   -- | Type-level metadata
   type MetadataOf a :: [(Symbol, Type)]

--- a/src/Data/Record/TH/CodeGen.hs
+++ b/src/Data/Record/TH/CodeGen.hs
@@ -571,12 +571,14 @@ genConstraintsClassInstance opts r@Record{..} = do
 --
 -- > type Constraints (T a b) = Constraints_T a b
 genInstanceConstraints :: Options -> Record () -> Q Dec
-genInstanceConstraints _opts r@Record{..} = tySynInstD $
-    tySynEqn
-      Nothing
-      [t| Constraints $(recordTypeT N.Unqual r) |]
-      (appsT (N.conT (N.unqualified (nameRecordConstraintsClass recordType))) $
-         map tyVarType recordTVars)
+genInstanceConstraints _opts r@Record{..} = do
+    c <- newName "c"
+    tySynInstD $
+      tySynEqn
+        Nothing
+        [t| Constraints $(recordTypeT N.Unqual r) $(varT c) |]
+        ((appsT (N.conT (N.unqualified (nameRecordConstraintsClass recordType))) $
+           map tyVarType recordTVars) `appT` varT c)
 
 -- | Generate metadata
 --


### PR DESCRIPTION
We never partially apply `Constraints`, and this avoids some class aliases in user code.