### PR TITLE
Revert "Allow `Constraints` to depend on both variables"

### DIFF
--- a/src/Data/Record/Generic.hs
+++ b/src/Data/Record/Generic.hs
@@ -43,7 +43,7 @@ import qualified Data.Record.Generic.Rep.Internal as Rep
 
 class Generic a where
   -- | @Constraints a c@ means "all fields of @a@ satisfy @c@"
-  type Constraints a (c :: Type -> Constraint) :: Constraint
+  type Constraints a :: (Type -> Constraint) -> Constraint
 
   -- | Type-level metadata
   type MetadataOf a :: [(Symbol, Type)]

--- a/src/Data/Record/TH/CodeGen.hs
+++ b/src/Data/Record/TH/CodeGen.hs
@@ -571,14 +571,12 @@ genConstraintsClassInstance opts r@Record{..} = do
 --
 -- > type Constraints (T a b) = Constraints_T a b
 genInstanceConstraints :: Options -> Record () -> Q Dec
-genInstanceConstraints _opts r@Record{..} = do
-    c <- newName "c"
-    tySynInstD $
-      tySynEqn
-        Nothing
-        [t| Constraints $(recordTypeT N.Unqual r) $(varT c) |]
-        ((appsT (N.conT (N.unqualified (nameRecordConstraintsClass recordType))) $
-           map tyVarType recordTVars) `appT` varT c)
+genInstanceConstraints _opts r@Record{..} = tySynInstD $
+    tySynEqn
+      Nothing
+      [t| Constraints $(recordTypeT N.Unqual r) |]
+      (appsT (N.conT (N.unqualified (nameRecordConstraintsClass recordType))) $
+         map tyVarType recordTVars)
 
 -- | Generate metadata
 --


### PR DESCRIPTION
This reverts commit a447a96954e75bfff22369a0fb0a3c8b34ed3c71.

It turns out that this does not actually help, and in fact encourages instances that result in large core size. Details in the forthcoming blog post.