### PR TITLE
Make record-dot-preprocessor optional

### DIFF
--- a/large-records.cabal
+++ b/large-records.cabal
@@ -144,7 +144,6 @@ test-suite test-large-records
                       , newtype
                       , microlens
                       , mtl
-                      , record-dot-preprocessor
                       , record-hasfield
                       , sop-core
                       , tasty
@@ -154,7 +153,6 @@ test-suite test-large-records
                       , transformers
                       , vector
                       , QuickCheck
-    build-tool-depends: record-dot-preprocessor:record-dot-preprocessor
     hs-source-dirs:     test
     default-language:   Haskell2010
     ghc-options:       -Wall
@@ -165,6 +163,11 @@ test-suite test-large-records
                        -Widentities
                        -- Needed for the AllZip tests
                        -freduction-depth=2000
+
+    if flag(use-RDP)
+      build-depends:      record-dot-preprocessor
+      build-tool-depends: record-dot-preprocessor:record-dot-preprocessor
+      cpp-options:        -DUSE_RDP
 
     if flag(profile-allzip)
       cpp-options: -DPROFILE_ALLZIP
@@ -294,6 +297,10 @@ Flag build-all-modules
   Description: Build all test modules in Size
   Default: False
 
+Flag use-RDP
+  Description: Use record-dot-preprocessor in the test suite
+  Default: True
+
 Flag use-ghc-dump
   Description: use ghc-dump to output AST sizes
   Default: False
@@ -313,3 +320,4 @@ Flag blog2-variant-quadratic
 Flag blog2-variant-sop
   Description: (For blog2 experiments) Variant that uses SOP generics rather than LR generics
   Default: False
+

--- a/test/Test/Record/Sanity/OverloadingNoDRF.hs
+++ b/test/Test/Record/Sanity/OverloadingNoDRF.hs
@@ -1,19 +1,30 @@
 {-# LANGUAGE ConstraintKinds       #-}
+{-# LANGUAGE CPP                   #-}
 {-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE QuasiQuotes           #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE TemplateHaskell       #-}
+{-# LANGUAGE TypeApplications      #-}
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE UndecidableInstances  #-}
 
+#if USE_RDP
 {-# OPTIONS_GHC -F -pgmF=record-dot-preprocessor #-}
+#endif
+
 -- {-# OPTIONS_GHC -ddump-splices #-}
 
 module Test.Record.Sanity.OverloadingNoDRF (
     tests
   ) where
+
+#if !USE_RDP
+import GHC.Records.Compat
+#endif
 
 import Data.Record.TH
 
@@ -31,8 +42,13 @@ largeRecord defaultPureScript [d|
 
 testOverloading :: Assertion
 testOverloading = do
+#if USE_RDP
     assertEqual "X" x.a 0
     assertEqual "Y" y.a "hi"
+#else
+    assertEqual "X" (getField @"a" x) 0
+    assertEqual "Y" (getField @"a" y) "hi"
+#endif
   where
     x :: X
     x = [lr| MkX {a = 0} |]

--- a/test/Test/Record/Sanity/QualifiedImports.hs
+++ b/test/Test/Record/Sanity/QualifiedImports.hs
@@ -1,15 +1,23 @@
+{-# LANGUAGE CPP                   #-}
 {-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE QuasiQuotes           #-}
 {-# LANGUAGE TypeApplications      #-}
 {-# LANGUAGE ViewPatterns          #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
 
+#if USE_RDP
 {-# OPTIONS_GHC -fplugin=RecordDotPreprocessor #-}
+#endif
+
 -- {-# OPTIONS_GHC -ddump-splices #-}
 
 module Test.Record.Sanity.QualifiedImports (tests) where
 
 import Data.Record.TH
+
+#if !USE_RDP
+import GHC.Records.Compat
+#endif
 
 import Test.Tasty
 import Test.Tasty.HUnit
@@ -36,10 +44,15 @@ tests = testGroup "Test.Record.Sanity.QualifiedImports" [
 
 testQualifiedImports :: Assertion
 testQualifiedImports = do
-    assertEqual "constructA" a.x          5
-    assertEqual "projectA"   (projectA a) (5, [True])
-    assertEqual "constructB" b.x          'a'
-    assertEqual "projectB"   (projectB b) ('a', 2, [True, False])
+    assertEqual "projectA" (projectA a) (5, [True])
+    assertEqual "projectB" (projectB b) ('a', 2, [True, False])
+#if USE_RDP
+    assertEqual "constructA" a.x 5
+    assertEqual "constructB" b.x 'a'
+#else
+    assertEqual "constructA" (getField @"x" a) 5
+    assertEqual "constructB" (getField @"x" b) 'a'
+#endif
   where
     a :: A.T Bool
     a = constructA

--- a/test/Test/Record/Sanity/RecordConstruction.hs
+++ b/test/Test/Record/Sanity/RecordConstruction.hs
@@ -1,19 +1,28 @@
 {-# LANGUAGE ConstraintKinds       #-}
+{-# LANGUAGE CPP                   #-}
 {-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE QuasiQuotes           #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE TemplateHaskell       #-}
+{-# LANGUAGE TypeApplications      #-}
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE UndecidableInstances  #-}
 
+#if USE_RDP
 {-# OPTIONS_GHC -F -pgmF=record-dot-preprocessor #-}
+#endif
+
+--{-# OPTIONS_GHC -Wwarn #-}
+
 -- {-# OPTIONS_GHC -ddump-splices #-}
-{-# OPTIONS_GHC -Wwarn #-}
 
 module Test.Record.Sanity.RecordConstruction (tests) where
+
+import GHC.Records.Compat
 
 import Data.Record.TH
 
@@ -77,8 +86,16 @@ tests = testGroup "Test.Record.Sanity.RecordConstruction" [
 
 testAllEqual :: Assertion
 testAllEqual = do
+#if USE_RDP
     assertEqual "inOrder/outOfOrder" inOrder.x  outOfOrder.x
     assertEqual "inOrder/withoutQQ"  inOrder.x  constructorApp.x
     assertEqual "R/S"                inOrder.x  valueOfS.x
     assertEqual "T/S"                valueOfT.y valueOfS
     assertEqual "T/R"                valueOfT.z (RR 5)
+#else
+    assertEqual "inOrder/outOfOrder" (getField @"x" inOrder)  (getField @"x" outOfOrder)
+    assertEqual "inOrder/withoutQQ"  (getField @"x" inOrder)  (getField @"x" constructorApp)
+    assertEqual "R/S"                (getField @"x" inOrder)  (getField @"x" valueOfS)
+    assertEqual "T/S"                (getField @"y" valueOfT) valueOfS
+    assertEqual "T/R"                (getField @"z" valueOfT) (RR 5)
+#endif

--- a/test/Test/Record/Size/Before/R010.hs
+++ b/test/Test/Record/Size/Before/R010.hs
@@ -11,7 +11,9 @@
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE UndecidableInstances  #-}
 
+#if USE_RDP
 {-# OPTIONS_GHC -fplugin=RecordDotPreprocessor #-}
+#endif
 
 #if USE_GHC_DUMP
 {-# OPTIONS_GHC -fplugin=GhcDump.Plugin #-}
@@ -22,6 +24,7 @@ module Test.Record.Size.Before.R010 where
 import Data.Aeson
 import Generics.SOP.JSON
 import Generics.SOP.TH
+import GHC.Records.Compat
 
 import Test.Record.Size.Infra
 
@@ -47,3 +50,14 @@ deriveGeneric ''R
 
 instance ToJSON R where
   toJSON = gtoJSON defaultJsonOptions
+
+-- For the sake of testing, we define one HasField instance by hand if RDP is
+-- not used. We're careful not to depend on field selectors, so that this still
+-- works NoFieldSelectors.
+#if !USE_RDP
+instance HasField "field1" R (T 1) where
+  hasField (MkR f1 f2 f3 f4 f5 f6 f7 f8 f9 f10) = (
+        \f1' -> MkR f1' f2 f3 f4 f5 f6 f7 f8 f9 f10
+      , f1
+      )
+#endif

--- a/test/Test/Record/Size/Before/R020.hs
+++ b/test/Test/Record/Size/Before/R020.hs
@@ -11,7 +11,9 @@
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE UndecidableInstances  #-}
 
+#if USE_RDP
 {-# OPTIONS_GHC -fplugin=RecordDotPreprocessor #-}
+#endif
 
 #if USE_GHC_DUMP
 {-# OPTIONS_GHC -fplugin=GhcDump.Plugin #-}

--- a/test/Test/Record/Size/Before/R030.hs
+++ b/test/Test/Record/Size/Before/R030.hs
@@ -11,7 +11,9 @@
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE UndecidableInstances  #-}
 
+#if USE_RDP
 {-# OPTIONS_GHC -fplugin=RecordDotPreprocessor #-}
+#endif
 
 #if USE_GHC_DUMP
 {-# OPTIONS_GHC -fplugin=GhcDump.Plugin #-}

--- a/test/Test/Record/Size/Before/R040.hs
+++ b/test/Test/Record/Size/Before/R040.hs
@@ -11,7 +11,9 @@
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE UndecidableInstances  #-}
 
+#if USE_RDP
 {-# OPTIONS_GHC -fplugin=RecordDotPreprocessor #-}
+#endif
 
 #if USE_GHC_DUMP
 {-# OPTIONS_GHC -fplugin=GhcDump.Plugin #-}

--- a/test/Test/Record/Size/Before/R050.hs
+++ b/test/Test/Record/Size/Before/R050.hs
@@ -11,7 +11,9 @@
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE UndecidableInstances  #-}
 
+#if USE_RDP
 {-# OPTIONS_GHC -fplugin=RecordDotPreprocessor #-}
+#endif
 
 #if USE_GHC_DUMP
 {-# OPTIONS_GHC -fplugin=GhcDump.Plugin #-}

--- a/test/Test/Record/Size/Before/R060.hs
+++ b/test/Test/Record/Size/Before/R060.hs
@@ -11,7 +11,9 @@
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE UndecidableInstances  #-}
 
+#if USE_RDP
 {-# OPTIONS_GHC -fplugin=RecordDotPreprocessor #-}
+#endif
 
 #if USE_GHC_DUMP
 {-# OPTIONS_GHC -fplugin=GhcDump.Plugin #-}

--- a/test/Test/Record/Size/Before/R070.hs
+++ b/test/Test/Record/Size/Before/R070.hs
@@ -11,7 +11,9 @@
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE UndecidableInstances  #-}
 
+#if USE_RDP
 {-# OPTIONS_GHC -fplugin=RecordDotPreprocessor #-}
+#endif
 
 #if USE_GHC_DUMP
 {-# OPTIONS_GHC -fplugin=GhcDump.Plugin #-}

--- a/test/Test/Record/Size/Before/R080.hs
+++ b/test/Test/Record/Size/Before/R080.hs
@@ -11,7 +11,9 @@
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE UndecidableInstances  #-}
 
+#if USE_RDP
 {-# OPTIONS_GHC -fplugin=RecordDotPreprocessor #-}
+#endif
 
 #if USE_GHC_DUMP
 {-# OPTIONS_GHC -fplugin=GhcDump.Plugin #-}

--- a/test/Test/Record/Size/Before/R090.hs
+++ b/test/Test/Record/Size/Before/R090.hs
@@ -11,7 +11,9 @@
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE UndecidableInstances  #-}
 
+#if USE_RDP
 {-# OPTIONS_GHC -fplugin=RecordDotPreprocessor #-}
+#endif
 
 #if USE_GHC_DUMP
 {-# OPTIONS_GHC -fplugin=GhcDump.Plugin #-}

--- a/test/Test/Record/Size/Before/R100.hs
+++ b/test/Test/Record/Size/Before/R100.hs
@@ -11,7 +11,9 @@
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE UndecidableInstances  #-}
 
+#if USE_RDP
 {-# OPTIONS_GHC -fplugin=RecordDotPreprocessor #-}
+#endif
 
 #if USE_GHC_DUMP
 {-# OPTIONS_GHC -fplugin=GhcDump.Plugin #-}


### PR DESCRIPTION
We _always_ provide the necessary instances, but the use of the plugin (which was anyway only used within the test suite) is now optional.