### PR TITLE
Template Haskell fix for GHC 9.0 compatibility

### DIFF
--- a/src/Data/Record/Internal/TH/Compat.hs
+++ b/src/Data/Record/Internal/TH/Compat.hs
@@ -6,10 +6,10 @@ module Data.Record.Internal.TH.Compat (
     TyVarBndr
   , pattern PlainTV
   , pattern KindedTV
-  , forallT
+  , forallT, forallC
   ) where
 
-import Language.Haskell.TH hiding (TyVarBndr(..), forallT)
+import Language.Haskell.TH hiding (TyVarBndr(..), forallT, forallC)
 -- import Language.Haskell.TH.Lib hiding (forallT)
 
 import qualified Language.Haskell.TH as TH
@@ -40,3 +40,9 @@ forallT = TH.forallT . map (fmap (const SpecifiedSpec))
 forallT = TH.forallT
 #endif
 
+forallC :: [TyVarBndr] -> CxtQ -> ConQ -> ConQ
+#if MIN_VERSION_template_haskell(2,17,0)
+forallC = TH.forallC . map (fmap (const SpecifiedSpec))
+#else
+forallC = TH.forallC
+#endif

--- a/src/Data/Record/TH/CodeGen.hs
+++ b/src/Data/Record/TH/CodeGen.hs
@@ -18,7 +18,7 @@ import Data.Proxy
 import Data.Vector (Vector)
 import GHC.Exts (Any)
 import GHC.Records.Compat
-import Language.Haskell.TH hiding (TyVarBndr(..), forallT)
+import Language.Haskell.TH hiding (TyVarBndr(..), forallC, forallT)
 import Language.Haskell.TH.Syntax (NameSpace(..))
 import Unsafe.Coerce (unsafeCoerce)
 
@@ -27,7 +27,6 @@ import qualified Data.Kind                  as Kind
 import qualified Data.Vector                as V
 import qualified GHC.Generics               as GHC
 import qualified Language.Haskell.TH.Syntax as TH
-import qualified Language.Haskell.TH.Lib    as TH
 
 import Data.Record.Generic
 import Data.Record.Generic.Eq
@@ -146,7 +145,7 @@ genDatatype Options{allFieldsStrict}
       (N.unqualified recordType)
       recordTVars
       Nothing
-      [ TH.forallC (map (N.plainLocalTV . snd) vars) (cxt $ map (uncurry eqConstraint) vars) $
+      [ forallC (map (N.plainLocalTV . snd) vars) (cxt $ map (uncurry eqConstraint) vars) $
           N.recC (N.unqualified recordConstr) $
             map (uncurry recordField) vars
       ]


### PR DESCRIPTION
The library didn't build on GHC 9.0 for me. This should fix it.