### PR TITLE
Compatibility with ghc 9.0

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -32,7 +32,7 @@ jobs:
             compilerKind: ghc
             compilerVersion: 9.2.1
             setup-method: ghcup
-            allow-failure: true
+            allow-failure: false
           - compiler: ghc-9.0.1
             compilerKind: ghc
             compilerVersion: 9.0.1
@@ -98,7 +98,7 @@ jobs:
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
-          if [ $((HCNUMVER >= 90200)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
+          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
           echo "GHCJSARITH=0" >> "$GITHUB_ENV"
         env:
@@ -127,17 +127,6 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
-          if $HEADHACKAGE; then
-          cat >> $CABAL_CONFIG <<EOF
-          repository head.hackage.ghc.haskell.org
-             url: https://ghc.gitlab.haskell.org/head.hackage/
-             secure: True
-             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
-                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
-                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
-             key-threshold: 3
-          EOF
-          fi
           cat >> $CABAL_CONFIG <<EOF
           program-default-options
             ghc-options: $GHCJOBS +RTS -M3G -RTS
@@ -168,7 +157,7 @@ jobs:
         run: |
           touch cabal.project
           echo "packages: $GITHUB_WORKSPACE/source/large-generics" >> cabal.project
-          if [ $((HCNUMVER < 90000)) -ne 0 ] ; then echo "packages: $GITHUB_WORKSPACE/source/large-records" >> cabal.project ; fi
+          if [ $((HCNUMVER < 90200)) -ne 0 ] ; then echo "packages: $GITHUB_WORKSPACE/source/large-records" >> cabal.project ; fi
           cat cabal.project
       - name: sdist
         run: |
@@ -188,16 +177,13 @@ jobs:
           touch cabal.project
           touch cabal.project.local
           echo "packages: ${PKGDIR_large_generics}" >> cabal.project
-          if [ $((HCNUMVER < 90000)) -ne 0 ] ; then echo "packages: ${PKGDIR_large_records}" >> cabal.project ; fi
+          if [ $((HCNUMVER < 90200)) -ne 0 ] ; then echo "packages: ${PKGDIR_large_records}" >> cabal.project ; fi
           echo "package large-generics" >> cabal.project
           echo "    ghc-options: -Werror=missing-methods" >> cabal.project
-          if [ $((HCNUMVER < 90000)) -ne 0 ] ; then echo "package large-records" >> cabal.project ; fi
-          if [ $((HCNUMVER < 90000)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
+          if [ $((HCNUMVER < 90200)) -ne 0 ] ; then echo "package large-records" >> cabal.project ; fi
+          if [ $((HCNUMVER < 90200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
           cat >> cabal.project <<EOF
           EOF
-          if $HEADHACKAGE; then
-          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
-          fi
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(large-generics|large-records)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local
@@ -228,8 +214,8 @@ jobs:
         run: |
           cd ${PKGDIR_large_generics} || false
           ${CABAL} -vnormal check
-          if [ $((HCNUMVER < 90000)) -ne 0 ] ; then cd ${PKGDIR_large_records} || false ; fi
-          if [ $((HCNUMVER < 90000)) -ne 0 ] ; then ${CABAL} -vnormal check ; fi
+          if [ $((HCNUMVER < 90200)) -ne 0 ] ; then cd ${PKGDIR_large_records} || false ; fi
+          if [ $((HCNUMVER < 90200)) -ne 0 ] ; then ${CABAL} -vnormal check ; fi
       - name: haddock
         run: |
           $CABAL v2-haddock $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -53,7 +53,7 @@ no-tests-no-benchmarks: True
 unconstrained: True
 
 -- Use head.hackage repository. Also marks as allow-failures
-head-hackage: >=9.2
+head-hackage: >=9.3
 
 -- Run tests with GHCJS (experimental, relies on cabal-plan finding test-suites)
 ghcjs-tests: False

--- a/large-records/large-records.cabal
+++ b/large-records/large-records.cabal
@@ -16,7 +16,7 @@ author:             Edsko de Vries
 maintainer:         edsko@well-typed.com
 category:           Generics
 extra-source-files: CHANGELOG.md
-tested-with:        GHC ==8.8.4 || ==8.10.7
+tested-with:        GHC ==8.8.4 || ==8.10.7 || ==9.0.1
 
 source-repository head
   type:     git

--- a/large-records/src/Data/Record/Internal/TH/Compat.hs
+++ b/large-records/src/Data/Record/Internal/TH/Compat.hs
@@ -6,10 +6,10 @@ module Data.Record.Internal.TH.Compat (
     TyVarBndr
   , pattern PlainTV
   , pattern KindedTV
-  , forallT
+  , forallT, forallC
   ) where
 
-import Language.Haskell.TH hiding (TyVarBndr(..), forallT)
+import Language.Haskell.TH hiding (TyVarBndr(..), forallT, forallC)
 -- import Language.Haskell.TH.Lib hiding (forallT)
 
 import qualified Language.Haskell.TH as TH
@@ -40,3 +40,9 @@ forallT = TH.forallT . map (fmap (const SpecifiedSpec))
 forallT = TH.forallT
 #endif
 
+forallC :: [TyVarBndr] -> CxtQ -> ConQ -> ConQ
+#if MIN_VERSION_template_haskell(2,17,0)
+forallC = TH.forallC . map (fmap (const SpecifiedSpec))
+#else
+forallC = TH.forallC
+#endif

--- a/large-records/src/Data/Record/TH/CodeGen.hs
+++ b/large-records/src/Data/Record/TH/CodeGen.hs
@@ -18,7 +18,7 @@ import Data.Proxy
 import Data.Vector (Vector)
 import GHC.Exts (Any)
 import GHC.Records.Compat
-import Language.Haskell.TH hiding (TyVarBndr(..), forallT)
+import Language.Haskell.TH hiding (TyVarBndr(..), forallC, forallT)
 import Language.Haskell.TH.Syntax (NameSpace(..))
 import Unsafe.Coerce (unsafeCoerce)
 
@@ -27,7 +27,6 @@ import qualified Data.Kind                  as Kind
 import qualified Data.Vector                as V
 import qualified GHC.Generics               as GHC
 import qualified Language.Haskell.TH.Syntax as TH
-import qualified Language.Haskell.TH.Lib    as TH
 
 import Data.Record.Generic
 import Data.Record.Generic.Eq
@@ -147,7 +146,7 @@ genDatatype Options{allFieldsStrict}
       (N.unqualified recordType)
       recordTVars
       Nothing
-      [ TH.forallC (map (N.plainLocalTV . snd) vars) (cxt $ map (uncurry eqConstraint) vars) $
+      [ forallC (map (N.plainLocalTV . snd) vars) (cxt $ map (uncurry eqConstraint) vars) $
           N.recC (N.unqualified recordConstr) $
             map (uncurry recordField) vars
       ]


### PR DESCRIPTION
This is effectively #44 rebased, plus an update to CI to enable 9.0. This depends on `json-sop` version 2.1, which I just released.

Compatibility with 9.2 might be a bit trickier, since the situation with `record-dot-preprocessor` there is unclear.