### PR TITLE
Fix definition of `checkAllFieldsKnown`

### DIFF
--- a/large-anon/large-anon.cabal
+++ b/large-anon/large-anon.cabal
@@ -43,9 +43,11 @@ library
     , containers
     , ghc-tcplugin-api >= 0.7.1
     , large-generics
+    , mtl
     , record-hasfield
     , sop-core
     , text
+    , vector
 
       -- Whatever version is bundled with ghc
     , ghc
@@ -69,6 +71,7 @@ test-suite test-large-anon
   other-modules:
       Test.Record.Anonymous.Sanity.Basics
       Test.Record.Anonymous.Sanity.Casting
+      Test.Record.Anonymous.Sanity.DuplicateFields
       Test.Record.Anonymous.Sanity.Merging
       Test.Record.Anonymous.Sanity.Named.Record1
       Test.Record.Anonymous.Sanity.Named.Record2

--- a/large-anon/src/Data/Record/Anonymous/Internal.hs
+++ b/large-anon/src/Data/Record/Anonymous/Internal.hs
@@ -115,6 +115,8 @@ import qualified Data.Record.Generic.Rep.Internal as Rep
 -- unresolved until we know more about the record.
 newtype Record (r :: [(Symbol, Type)]) = MkR (Map String Any)
 
+-- TODO: Give role annotation (representational)
+
 data Field l where
   Field :: KnownSymbol l => Proxy l -> Field l
 
@@ -267,7 +269,6 @@ set :: forall l r a.
      HasField l (Record r) a
   => Field l -> a -> Record r -> Record r
 set _ = flip (setField @l @(Record r))
-
 
 {-------------------------------------------------------------------------------
   Generics

--- a/large-anon/test/Test/Record/Anonymous/Sanity/DuplicateFields.hs
+++ b/large-anon/test/Test/Record/Anonymous/Sanity/DuplicateFields.hs
@@ -1,0 +1,59 @@
+{-# LANGUAGE DataKinds        #-}
+{-# LANGUAGE OverloadedLabels #-}
+
+{-# OPTIONS_GHC -fplugin=Data.Record.Anonymous.Plugin #-}
+
+module Test.Record.Anonymous.Sanity.DuplicateFields (tests) where
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import Data.Record.Anonymous
+
+tests :: TestTree
+tests = testGroup "Test.Record.Anonymous.Sanity.DuplicateFields" [
+      testCase "insertSameType"      test_insertSameType
+    , testCase "insertDifferentType" test_insertDifferentType
+    , testCase "mergeSameType"       test_mergeSameType
+    , testCase "mergeDifferentType"  test_mergeDifferentType
+    ]
+
+test_insertSameType :: Assertion
+test_insertSameType = do
+    assertEqual "" expected actual
+  where
+    actual :: Record '[ '("a", Bool) ]
+    actual = castRecord $ insert #a True $ insert #a False $ empty
+
+    expected :: Record '[ '("a", Bool) ]
+    expected = insert #a True $ empty
+
+test_insertDifferentType :: Assertion
+test_insertDifferentType = do
+    assertEqual "" expected actual
+  where
+    actual :: Record '[ '("a", Bool) ]
+    actual = castRecord $ insert #a True $ insert #a 'a' $ empty
+
+    expected :: Record '[ '("a", Bool) ]
+    expected = insert #a True $ empty
+
+test_mergeSameType :: Assertion
+test_mergeSameType = do
+    assertEqual "" expected actual
+  where
+    actual :: Record '[ '("a", Bool) ]
+    actual = castRecord $ merge (insert #a True empty) (insert #a False empty)
+
+    expected :: Record '[ '("a", Bool) ]
+    expected = insert #a True $ empty
+
+test_mergeDifferentType :: Assertion
+test_mergeDifferentType = do
+    assertEqual "" expected actual
+  where
+    actual :: Record '[ '("a", Bool) ]
+    actual = castRecord $ merge (insert #a True empty) (insert #a 'a' empty)
+
+    expected :: Record '[ '("a", Bool) ]
+    expected = insert #a True $ empty

--- a/large-anon/test/TestLargeAnon.hs
+++ b/large-anon/test/TestLargeAnon.hs
@@ -5,10 +5,12 @@ import Test.Tasty
 import qualified Test.Record.Anonymous.Sanity.Basics
 import qualified Test.Record.Anonymous.Sanity.Merging
 import qualified Test.Record.Anonymous.Sanity.Casting
+import qualified Test.Record.Anonymous.Sanity.DuplicateFields
 
 main :: IO ()
 main = defaultMain $ testGroup "large-anon" [
       Test.Record.Anonymous.Sanity.Basics.tests
     , Test.Record.Anonymous.Sanity.Merging.tests
     , Test.Record.Anonymous.Sanity.Casting.tests
+    , Test.Record.Anonymous.Sanity.DuplicateFields.tests
     ]


### PR DESCRIPTION
This wasn't correctly dealing with the fact that earlier fields shadow
later fields. This also adds some tests for duplicate fields.