### PR TITLE
Add functor parameter to `Record`

### DIFF
--- a/large-anon/src/Data/Record/Anonymous.hs
+++ b/large-anon/src/Data/Record/Anonymous.hs
@@ -42,9 +42,9 @@ import Data.Record.Anonymous.Internal
 -------------------------------------------------------------------------------}
 
 -- | Show type of every field in the record
-describeRecord :: forall proxy r.
-     RecordConstraints r Typeable
-  => proxy r  -- Proxy for the record (note: can use a record itself as a proxy)
+describeRecord :: forall proxy f r.
+     RecordConstraints f r Typeable
+  => proxy f r  -- Proxy for the record (note: can use a record itself as a proxy)
   -> String
 describeRecord _ =
       combine
@@ -52,9 +52,12 @@ describeRecord _ =
     . Rep.cmap (Proxy @Typeable) aux
     $ names
   where
-    names :: Rep (K String) (Record r)
-    names = recordFieldNames $ metadata (Proxy @(Record r))
+    names :: Rep (K String) (Record f r)
+    names = recordFieldNames $ metadata (Proxy @(Record f r))
 
+    -- @x@ here will be of the form @f x'@, for some @x'@, and we have a
+    -- constraint @Typeable (f x')@ in scope. We therefore do not need to
+    -- manually apply @f@ here.
     aux :: forall x. Typeable x => K String x -> K String x
     aux (K name) = K $ name ++ " :: " ++ show (typeRep (Proxy @x))
 

--- a/large-anon/src/Data/Record/Anonymous/Plugin/Record.hs
+++ b/large-anon/src/Data/Record/Anonymous/Plugin/Record.hs
@@ -294,14 +294,14 @@ instance Outputable FieldLabel where
   Parser
 -------------------------------------------------------------------------------}
 
--- | Parse @Record r@
+-- | Parse @Record f r@
 --
--- Returns the argument @r@
-parseRecord :: TyConSubst -> ResolvedNames -> Type -> Maybe Type
+-- Returns the argument @f, r@
+parseRecord :: TyConSubst -> ResolvedNames -> Type -> Maybe (Type, Type)
 parseRecord tcs ResolvedNames{..} t = do
     args <- parseInjTyConApp tcs tyConRecord t
     case args of
-      [r]        -> Just r
+      [f, r]     -> Just (f, r)
       _otherwise -> Nothing
 
 parseFields :: TyConSubst -> ResolvedNames -> Type -> Maybe Fields

--- a/large-anon/test/Test/Record/Anonymous/Sanity/Basics.hs
+++ b/large-anon/test/Test/Record/Anonymous/Sanity/Basics.hs
@@ -3,10 +3,12 @@
 {-# LANGUAGE TypeApplications #-}
 
 {-# OPTIONS_GHC -fplugin=Data.Record.Anonymous.Plugin #-}
+{-# OPTIONS_GHC -Wno-orphans #-} -- for the ToJSON/FromJSON instances
 
 module Test.Record.Anonymous.Sanity.Basics (tests) where
 
 import Data.Aeson
+import Data.SOP.BasicFunctors -- TODO: Should this be exported from large-anon?
 
 import qualified Data.Record.Anonymous as A
 
@@ -30,56 +32,56 @@ tests = testGroup "Test.Record.Anonymous.Sanity.Basics" [
   Tests proper
 -------------------------------------------------------------------------------}
 
-record1 :: A.Record '[ '("x", Bool), '("y", Char), '("z", ()) ]
+record1 :: A.Record I '[ '("x", Bool), '("y", Char), '("z", ()) ]
 record1 =
-      A.insert #x True
-    $ A.insert #y 'a'
-    $ A.insert #z ()
+      A.insert #x (I True)
+    $ A.insert #y (I 'a')
+    $ A.insert #z (I ())
     $ A.empty
 
 -- | Second example, where the fields do not appear in alphabetical order
 --
 -- Ordering matters in the 'Generic' instance.
-record2 :: A.Record '[ '("y", Char), '("x", Bool) ]
+record2 :: A.Record I '[ '("y", Char), '("x", Bool) ]
 record2 =
-      A.insert #y 'a'
-    $ A.insert #x True
+      A.insert #y (I 'a')
+    $ A.insert #x (I True)
     $ A.empty
 
 test_HasField :: Assertion
 test_HasField = do
-    assertEqual "get field 1" True $ (A.get #x record1)
-    assertEqual "get field 2" 'a'  $ (A.get #y record1)
-    assertEqual "get field 3" ()   $ (A.get #z record1)
+    assertEqual "get field 1" (I True) $ (A.get #x record1)
+    assertEqual "get field 2" (I 'a')  $ (A.get #y record1)
+    assertEqual "get field 3" (I ())   $ (A.get #z record1)
 
     -- TODO: We should do whole-record comparisons, but for that we need
     -- Show and Eq instances, which will depend on generics
 
-    assertEqual "set field 1, then get field 1" False $
-      A.get #x (A.set #x False record1)
-    assertEqual "set field 1, then get field 2" 'a' $
-      (A.get #y (A.set #x False record1))
+    assertEqual "set field 1, then get field 1" (I False) $
+      A.get #x (A.set #x (I False) record1)
+    assertEqual "set field 1, then get field 2" (I 'a') $
+      (A.get #y (A.set #x (I False) record1))
 
     -- TODO: think about and test what happens with duplicate labels
 
 test_Show :: Assertion
 test_Show = do
-    assertEqual "R1" (show (R1.Record True 'a' ())) $ show record1
-    assertEqual "R2" (show (R2.Record 'a' True))    $ show record2
+    assertEqual "R1" (show (R1.Record (I True) (I 'a') (I ()))) $ show record1
+    assertEqual "R2" (show (R2.Record (I 'a') (I True)))        $ show record2
 
 test_Eq :: Assertion
 test_Eq = do
     assertEqual "equal" True $
       record1 == record1
     assertEqual "not equal" False $
-      record1 == (A.set #x False record1)
+      record1 == (A.set #x (I False) record1)
 
 test_Ord :: Assertion
 test_Ord = do
-    assertEqual "R1" (compare (R1.Record True 'a' ()) (R1.Record False 'a' ())) $
-      compare record1 (A.set #x False record1)
-    assertEqual "R2" (compare (R2.Record 'a' True) (R2.Record 'a' False)) $
-      compare record2 (A.set #x False record2)
+    assertEqual "R1" (compare (R1.Record (I True) (I 'a') (I ())) (R1.Record (I False) (I 'a') (I ()))) $
+      compare record1 (A.set #x (I False) record1)
+    assertEqual "R2" (compare (R2.Record (I 'a') (I True)) (R2.Record (I 'a') (I False))) $
+      compare record2 (A.set #x (I False) record2)
 
 -- Test 'describeRecord'
 --
@@ -92,9 +94,19 @@ test_describeRecord = do
     assertEqual "" expected $ A.describeRecord record1
   where
     expected :: String
-    expected = "Record {x :: Bool, y :: Char, z :: ()}"
+    expected = "Record {x :: I Bool, y :: I Char, z :: I ()}"
 
 test_JSON :: Assertion
 test_JSON = do
     assertEqual "R1" (Just record1) $ decode (encode record1)
     assertEqual "R2" (Just record2) $ decode (encode record2)
+
+{-------------------------------------------------------------------------------
+  Auxiliary
+-------------------------------------------------------------------------------}
+
+instance FromJSON a => FromJSON (I a) where
+  parseJSON = fmap I . parseJSON
+
+instance ToJSON a => ToJSON (I a) where
+  toJSON = toJSON . unI

--- a/large-anon/test/Test/Record/Anonymous/Sanity/Casting.hs
+++ b/large-anon/test/Test/Record/Anonymous/Sanity/Casting.hs
@@ -21,23 +21,23 @@ tests = testGroup "Test.Record.Anonymous.Sanity.Casting" [
   Example values
 -------------------------------------------------------------------------------}
 
-recordA :: Record '[ '("a", Bool), '("b", Char) ]
+recordA :: Record I '[ '("a", Bool), '("b", Char) ]
 recordA =
-      insert #a True
-    $ insert #b 'a'
+      insert #a (I True)
+    $ insert #b (I 'a')
     $ empty
 
-recordA' :: Record '[ '("b", Char), '("a", Bool) ]
+recordA' :: Record I '[ '("b", Char), '("a", Bool) ]
 recordA' =
-      insert #b 'a'
-    $ insert #a True
+      insert #b (I 'a')
+    $ insert #a (I True)
     $ empty
 
-recordWithMerge :: Record (Merge '[ '("a", Bool) ] '[ '("b", Char) ])
+recordWithMerge :: Record I (Merge '[ '("a", Bool) ] '[ '("b", Char) ])
 recordWithMerge =
     merge
-      (insert #a True $ empty)
-      (insert #b 'a'  $ empty)
+      (insert #a (I True) $ empty)
+      (insert #b (I 'a')  $ empty)
 
 {-------------------------------------------------------------------------------
   Tests proper

--- a/large-anon/test/Test/Record/Anonymous/Sanity/DuplicateFields.hs
+++ b/large-anon/test/Test/Record/Anonymous/Sanity/DuplicateFields.hs
@@ -22,38 +22,44 @@ test_insertSameType :: Assertion
 test_insertSameType = do
     assertEqual "" expected actual
   where
-    actual :: Record '[ '("a", Bool) ]
-    actual = castRecord $ insert #a True $ insert #a False $ empty
+    actual :: Record I '[ '("a", Bool) ]
+    actual = castRecord $ insert #a (I True)
+                        $ insert #a (I False)
+                        $ empty
 
-    expected :: Record '[ '("a", Bool) ]
-    expected = insert #a True $ empty
+    expected :: Record I '[ '("a", Bool) ]
+    expected = insert #a (I True) empty
 
 test_insertDifferentType :: Assertion
 test_insertDifferentType = do
     assertEqual "" expected actual
   where
-    actual :: Record '[ '("a", Bool) ]
-    actual = castRecord $ insert #a True $ insert #a 'a' $ empty
+    actual :: Record I '[ '("a", Bool) ]
+    actual = castRecord $ insert #a (I True)
+                        $ insert #a (I 'a')
+                        $ empty
 
-    expected :: Record '[ '("a", Bool) ]
-    expected = insert #a True $ empty
+    expected :: Record I '[ '("a", Bool) ]
+    expected = insert #a (I True) empty
 
 test_mergeSameType :: Assertion
 test_mergeSameType = do
     assertEqual "" expected actual
   where
-    actual :: Record '[ '("a", Bool) ]
-    actual = castRecord $ merge (insert #a True empty) (insert #a False empty)
+    actual :: Record I '[ '("a", Bool) ]
+    actual = castRecord $ merge (insert #a (I True)  empty)
+                                (insert #a (I False) empty)
 
-    expected :: Record '[ '("a", Bool) ]
-    expected = insert #a True $ empty
+    expected :: Record I '[ '("a", Bool) ]
+    expected = insert #a (I True) empty
 
 test_mergeDifferentType :: Assertion
 test_mergeDifferentType = do
     assertEqual "" expected actual
   where
-    actual :: Record '[ '("a", Bool) ]
-    actual = castRecord $ merge (insert #a True empty) (insert #a 'a' empty)
+    actual :: Record I '[ '("a", Bool) ]
+    actual = castRecord $ merge (insert #a (I True) empty)
+                                (insert #a (I 'a')  empty)
 
-    expected :: Record '[ '("a", Bool) ]
-    expected = insert #a True $ empty
+    expected :: Record I '[ '("a", Bool) ]
+    expected = insert #a (I True) empty

--- a/large-anon/test/Test/Record/Anonymous/Sanity/Merging.hs
+++ b/large-anon/test/Test/Record/Anonymous/Sanity/Merging.hs
@@ -23,24 +23,24 @@ tests = testGroup "Test.Record.Anonymous.Sanity.Merging" [
 -------------------------------------------------------------------------------}
 
 ab, ab' ::
-    Record (Merge '[ '("a", Bool), '("b", Int)]
-                  '[ '("c", Double), '("d", Char)])
+    Record I (Merge '[ '("a", Bool), '("b", Int)]
+                    '[ '("c", Double), '("d", Char)])
 ab  = merge a b
 ab' = merge a' b
 
-a, a' :: Record '[ '("a", Bool), '("b", Int)]
+a, a' :: Record I '[ '("a", Bool), '("b", Int)]
 a =
-    insert #a True
-  $ insert #b (1 :: Int)
+    insert #a (I True)
+  $ insert #b (I (1 :: Int))
   $ empty
 a' =
-    insert #a False
-  $ insert #b (1 :: Int)
+    insert #a (I False)
+  $ insert #b (I (1 :: Int))
   $ empty
 
-b :: Record '[ '("c", Double), '("d", Char)]
-b = insert #c 3.14
-  $ insert #d 'a'
+b :: Record I '[ '("c", Double), '("d", Char)]
+b = insert #c (I 3.14)
+  $ insert #d (I 'a')
   $ empty
 
 {-------------------------------------------------------------------------------
@@ -49,33 +49,33 @@ b = insert #c 3.14
 
 test_concrete :: Assertion
 test_concrete = do
-    assertEqual "get" True $ get #a ab
-    assertEqual "set" ab'  $ set #a False ab
+    assertEqual "get" (I True) $ get #a ab
+    assertEqual "set" ab'      $ set #a (I False) ab
 
 test_polymorphic :: Assertion
 test_polymorphic = do
-    assertEqual "get" 1   $ getPoly ab
-    assertEqual "set" ab' $ setPoly ab
+    assertEqual "get" (I 1) $ getPoly ab
+    assertEqual "set" ab'   $ setPoly ab
   where
-    getPoly :: Record (Merge '[ '("a", Bool), '("b", Int)] r) -> Int
+    getPoly :: Record I (Merge '[ '("a", Bool), '("b", Int)] r) -> I Int
     getPoly = get #b
 
     setPoly ::
-         Record (Merge '[ '("a", Bool), '("b", Int)] r)
-      -> Record (Merge '[ '("a", Bool), '("b", Int)] r)
-    setPoly = set #a False
+         Record I (Merge '[ '("a", Bool), '("b", Int)] r)
+      -> Record I (Merge '[ '("a", Bool), '("b", Int)] r)
+    setPoly = set #a (I False)
 
 -- | Test that type equalities are handled correctly
 test_eqConstraint :: Assertion
 test_eqConstraint = do
-    assertEqual "a" True $ f1 ab
-    assertEqual "b" 1    $ f2 ab
-    assertEqual "c" 3.14 $ f3 ab
+    assertEqual "a" (I True) $ f1 ab
+    assertEqual "b" (I 1)    $ f2 ab
+    assertEqual "c" (I 3.14) $ f3 ab
   where
     -- Single simple equality
     f1 :: row ~ Merge '[ '("a", Bool), '("b", Int)]
                       '[ '("c", Double), '("d", Char)]
-       => Record row -> Bool
+       => Record I row -> I Bool
     f1 = get #a
 
     -- Multiple (transitive) equalities
@@ -84,12 +84,12 @@ test_eqConstraint = do
           , row ~ tf1 '[ '("a", Bool), '("b", Int)]
                       '[ '("c", Double), '("d", Char)]
           )
-       => Record row -> Int
+       => Record I row -> I Int
     f2 = get #b
 
     -- Equality with partial application
     f3 :: ( merge ~ Merge '[ '("a", Bool), '("b", Int)]
           , row   ~ merge '[ '("c", Double), '("d", Char)]
           )
-       => Record row -> Double
+       => Record I row -> I Double
     f3 = get #c

--- a/large-anon/test/Test/Record/Anonymous/Sanity/Named/Record1.hs
+++ b/large-anon/test/Test/Record/Anonymous/Sanity/Named/Record1.hs
@@ -1,8 +1,13 @@
+{-# LANGUAGE StandaloneDeriving   #-}
+{-# LANGUAGE UndecidableInstances #-}
+
 module Test.Record.Anonymous.Sanity.Named.Record1 (
     Record(..)
   ) where
 
 -- | Non-anonymous record (for comparison with equivalent anonymous record)
-data Record = Record { x :: Bool, y :: Char, z :: () }
-  deriving (Show, Eq, Ord)
+data Record f = Record { x :: f Bool, y :: f Char, z :: f () }
 
+deriving instance (Show (f Bool), Show (f Char), Show (f ())) => Show (Record f)
+deriving instance (Eq   (f Bool), Eq   (f Char), Eq   (f ())) => Eq   (Record f)
+deriving instance (Ord  (f Bool), Ord  (f Char), Ord  (f ())) => Ord  (Record f)

--- a/large-anon/test/Test/Record/Anonymous/Sanity/Named/Record2.hs
+++ b/large-anon/test/Test/Record/Anonymous/Sanity/Named/Record2.hs
@@ -1,8 +1,14 @@
+{-# LANGUAGE StandaloneDeriving   #-}
+{-# LANGUAGE UndecidableInstances #-}
+
 module Test.Record.Anonymous.Sanity.Named.Record2 (
     Record(..)
   ) where
 
 -- | Non-anonymous record (for comparison with equivalent anonymous record)
-data Record = Record { y :: Char, x :: Bool }
-  deriving (Show, Eq, Ord)
+data Record f = Record { y :: f Char, x :: f Bool }
+
+deriving instance (Show (f Char), Show (f Bool)) => Show (Record f)
+deriving instance (Eq   (f Char), Eq   (f Bool)) => Eq   (Record f)
+deriving instance (Ord  (f Char), Ord  (f Bool)) => Ord  (Record f)
 


### PR DESCRIPTION
DONE:

- Added functor parameter to `Record`
- Updated solvers for
  * `HasField`
  * `RecordConstraints`
  * `RecordMetadata`
- Updated doctests 

TODO:

- Generic metadata
  (we don't currently have tests for these, we should add some)
- "Simple" interface without the parameter
- API for working with this `f` parameter (mapping etc.)