### PR TITLE
Experiment (large-anon): use IntMap keyed on FastString Unique

### DIFF
--- a/large-anon/large-anon.cabal
+++ b/large-anon/large-anon.cabal
@@ -27,6 +27,7 @@ library
       Data.Record.Anonymous.Plugin.Constraints.HasField
       Data.Record.Anonymous.Plugin.Constraints.Isomorphic
       Data.Record.Anonymous.Plugin.Constraints.RecordConstraints
+      Data.Record.Anonymous.Plugin.Constraints.RecordDicts
       Data.Record.Anonymous.Plugin.Constraints.RecordMetadata
       Data.Record.Anonymous.Plugin.GhcTcPluginAPI
       Data.Record.Anonymous.Plugin.NameResolution
@@ -70,17 +71,20 @@ test-suite test-large-anon
   main-is:
       TestLargeAnon.hs
   other-modules:
+      Test.Record.Anonymous.Prop.Combinators.Constrained
       Test.Record.Anonymous.Prop.Combinators.Simple
       Test.Record.Anonymous.Prop.Model
       Test.Record.Anonymous.Prop.Model.Generator
       Test.Record.Anonymous.Prop.Model.Orphans
-      Test.Record.Anonymous.Sanity.Basics
       Test.Record.Anonymous.Sanity.Casting
       Test.Record.Anonymous.Sanity.DuplicateFields
+      Test.Record.Anonymous.Sanity.Generics
+      Test.Record.Anonymous.Sanity.HasField
       Test.Record.Anonymous.Sanity.Merging
-      Test.Record.Anonymous.Sanity.TypeLevelMetadata
       Test.Record.Anonymous.Sanity.Named.Record1
       Test.Record.Anonymous.Sanity.Named.Record2
+      Test.Record.Anonymous.Sanity.RecordDicts
+      Test.Record.Anonymous.Sanity.TypeLevelMetadata
   build-depends:
       base
     , aeson

--- a/large-anon/large-anon.cabal
+++ b/large-anon/large-anon.cabal
@@ -26,6 +26,7 @@ library
   other-modules:
       Data.Record.Anonymous.Plugin.Constraints.HasField
       Data.Record.Anonymous.Plugin.Constraints.Isomorphic
+      Data.Record.Anonymous.Plugin.Constraints.KnownFieldLabel
       Data.Record.Anonymous.Plugin.Constraints.RecordConstraints
       Data.Record.Anonymous.Plugin.Constraints.RecordDicts
       Data.Record.Anonymous.Plugin.Constraints.RecordMetadata

--- a/large-anon/src/Data/Record/Anonymous/Internal.hs
+++ b/large-anon/src/Data/Record/Anonymous/Internal.hs
@@ -14,6 +14,7 @@
 {-# LANGUAGE UndecidableInstances  #-}
 
 {-# OPTIONS_GHC -Wno-redundant-constraints #-}
+{-# LANGUAGE ConstraintKinds #-}
 
 module Data.Record.Anonymous.Internal (
     -- * Types
@@ -45,13 +46,29 @@ module Data.Record.Anonymous.Internal (
   , pure
   , ap
     -- * Generics
-  , RecordConstraints(..)
-  , RecordMetadata(..)
+    -- ** Metadata
+  , RecordMetadata -- opaque
+  , recordMetadata
   , RecordMetadataOf
+    -- ** Conversion
+  , normalizeRecordRep
+  , denormalizeRecordRep
+  , recordToRep
+  , recordToRep'
+  , recordFromRep
+  , recordFromRep'
+  , recordToNormalizedRep
+  , recordFromNormalizedRep
+    -- ** Constraints
+  , RecordDicts(..)
+  , RecordDictsF
+  , recordDictsF
+  , RecordConstraints(..)
     -- * Internal API
   , unsafeRecordHasField
   , unsafeDictRecord
-  , unsafeFieldMetadata
+  , unsafeRecordDicts
+  , unsafeRecordMetadata
   ) where
 
 import Prelude hiding (map, mapM, zip, zipWith, sequenceA, pure)
@@ -68,10 +85,12 @@ import Data.Record.Generic.JSON
 import Data.Record.Generic.Rep.Internal (noInlineUnsafeCo)
 import Data.Record.Generic.Show
 import Data.SOP.BasicFunctors
+import Data.SOP.Constraint
 import GHC.Exts (Any)
 import GHC.OverloadedLabels
 import GHC.Records.Compat
 import GHC.TypeLits
+import Unsafe.Coerce (unsafeCoerce)
 
 import qualified Data.Foldable       as Foldable
 import qualified Data.Map            as Map
@@ -183,6 +202,16 @@ type family Merge :: [(Symbol, Type)] -> [(Symbol, Type)] -> [(Symbol, Type)]
 --
 -- See 'castRecord' for details.
 class Isomorphic (xs :: [(Symbol, Type)]) (ys :: [(Symbol, Type)])
+
+{-------------------------------------------------------------------------------
+  Internal API
+-------------------------------------------------------------------------------}
+
+recordToMap :: Record f r -> Map String (f Any)
+recordToMap (MkR r) = r
+
+recordFromMap :: Map String (f Any) -> Record f r
+recordFromMap = MkR
 
 {-------------------------------------------------------------------------------
   User-visible API
@@ -308,14 +337,6 @@ set _ = flip (setField @l @(Record f r))
   Simple (non-constrained) combinators
 -------------------------------------------------------------------------------}
 
--- | Internal function
-recordToMap :: Record f r -> Map String (f Any)
-recordToMap (MkR r) = r
-
--- | Internal function
-recordFromMap :: Map String (f Any) -> Record f r
-recordFromMap = MkR
-
 map :: (forall x. f x -> g x) -> Record f r -> Record g r
 map f = recordFromMap . fmap f . recordToMap
 
@@ -355,7 +376,7 @@ collapse = co . Foldable.toList . recordToMap
 sequenceA :: Applicative m => Record (m :.: f) r -> m (Record f r)
 sequenceA = fmap recordFromMap . traverse unComp . recordToMap
 
-pure :: forall f r. RecordMetadata f r => (forall x. f x) -> Record f r
+pure :: forall f r. RecordMetadata r => (forall x. f x) -> Record f r
 pure f = recordFromMap $ aux recordMetadata
   where
     aux :: Metadata (Record f r) -> Map String (f Any)
@@ -370,57 +391,231 @@ ap fs as = recordFromMap $
     Map.intersectionWith apFn (recordToMap fs) (recordToMap as)
 
 {-------------------------------------------------------------------------------
+  Constraints
+
+  [Note RecordDicts]
+
+  The constrained combinators on 'Record' are defined in terms of 'RecordDicts',
+  not 'RecordDictsF'. This is a non-trivial design choice which requires some
+  justification:
+
+  1. More primitive
+
+  Consider 'cpure' versus @cpureF@ (hypothetical, not offered by the lib):
+
+  > cpure  :: RecordDicts    r c => Proxy c -> (forall x. c    x  => f x) -> Record f r
+  > cpureF :: RecordDictsF f r c => Proxy c -> (forall x. c (f x) => f x) -> Record f r
+
+  At first glance, @cpureF@ might seem like the more logical choice; after all,
+  each field in the record has type @f x@ for some @x@. However, @cpureF@ is
+  easily defined in terms of 'cpure':
+
+  > cpureF _p f = cpure (Proxy @(Compose c f)) f
+
+  but we /cannot/ define `cpure` in terms of `cpureF`. We would have to pick
+  some functor @f@; we would like to choose the identify type family, but we
+  cannot (cannot partially apply type families). If instead we choose the
+  identity newtype, we have no guarantee that @c (I x)@ implies @c x@.
+
+  2. More natural
+
+  Consider 'cmap':
+
+  > cmap ::
+  >      RecordDicts r c
+  >   => Proxy c
+  >   -> (forall x. c x => f x -> g x)
+  >   -> Record f r -> Record g r
+  > cmap p f = ap $ cpure p (Fn f)
+
+  If we wanted to define this in terms of 'RecordDictsF', what should the
+  type of the callback be? Any of the following could be useful in different
+  circumstances:
+
+  > cmapF :: ... -> (forall x. (c (f x)         ) => f x -> g x) -> ...
+  > cmapF :: ... -> (forall x.           c (g x)) => f x -> g x) -> ...
+  > cmapF :: ... -> (forall x. (c (f x), c (g x)) => f x -> g x) -> ...
+
+  None of these is more general then the other (the third version is the most
+  general from the point of view of the callback, but the most restrictive
+  from the point of view of the caller of 'cmap').
+
+  Additionally, currently 'cmap' is defined in terms of 'cpure':
+
+  > cmap p f = ap (cpure p (Fn f) :: Record (f -.-> g) r)
+
+  It is not all obvious how we could define @cmapF@ (any of the three variants)
+  in terms of @cpureF@; we could probably define it directly in terms of
+  'recordDictsF' (like @cpureF@ itself), but now we are losing compositionality.
+
+  3. More in line with the combinators on 'Rep'
+
+  Compare
+
+  > cpure :: (Generic a, Constraints a c) => Proxy c -> (forall x. c x => f x) -> Rep    f a
+  > cpure ::             RecordDicts r c  => Proxy c -> (forall x. c x => f x) -> Record f r
+
+  The @large-generics@ infrastructure is defined over types of kind @Type@, not
+  over types of kind @(Type -> Type) -> Type@, and so the 'Constraints' /cannot/
+  include a functor argument. That doesn't mean of course that 'cpure' could not
+  be defined as
+
+  > cpure :: (Generic a, Constraints a (Compose c f)) => ..
+
+  but in the context of @large-generics@ the functor-less version is very
+  natural (and works well). That doesn't necessarily mean 'cpure' for 'Record'
+  should suit, of course, but it's nice that they do line up.
+-------------------------------------------------------------------------------}
+
+-- | Require @c a@ for every field of type @a@ in a @Record f r@
+--
+-- This does /not/ deal with the functor argument @f@ (see 'RecordDictsF').
+-- For a discussion on why 'RecordDicts' is primitive, see [Note RecordDicts].
+class RecordDicts r c where
+  recordDicts :: Proxy c -> Record (Dict c) r
+
+-- TODO: Provide way to go the other direction.
+
+-- | Require @c (f a)@ for every field of type @a@ in a @Record f r@
+class    RecordDicts r (Compose c f) => RecordDictsF f r c
+instance RecordDicts r (Compose c f) => RecordDictsF f r c
+
+recordDictsF :: forall c f r.
+     RecordDictsF f r c
+  => Proxy c -> Record (Dict c :.: f) r
+recordDictsF _ = map aux $ recordDicts (Proxy @(Compose c f))
+  where
+    aux :: Dict (Compose c f) x -> (Dict c :.: f) x
+    aux Dict = Comp Dict
+
+{-------------------------------------------------------------------------------
+  Generics: Metadata
+-------------------------------------------------------------------------------}
+
+-- | For the record metadata, the functor used for the 'Record' is irrelevant
+data Irrelevant (a :: Type)
+
+class RecordMetadata (r :: [(Symbol, Type)]) where
+  recordMetadata' :: Metadata (Record Irrelevant r)
+
+recordMetadata :: RecordMetadata r => Metadata (Record f r)
+recordMetadata = co recordMetadata'
+  where
+    co :: Metadata (Record Irrelevant r) -> Metadata (Record f r)
+    co = noInlineUnsafeCo
+
+{-------------------------------------------------------------------------------
+  Generics: Conversion to/from 'Rep'
+
+  It is unfortunate these these translations are @O(n log n)@. It is not obvious
+  however how to address this without making other operations more expensive.
+  In particular, we could decide the internal representation of a record to /be/
+  a vector, but if we do, 'insert' suddenly becomes @O(n)@, which would make a
+  repeated series of inserts (a common pattern) @O(n²)@. For now we just accept
+  the cost here: the cost is only incurred when translating to/from the generic
+  representation, and it's probably not a good idea to use generic code in
+  performance critical code anyway.
+
+  Both 'recordToRep' and 'recordFromRep' need the metadata:
+
+  - 'recordToRep' needs the metadata to determine the right order of the fields
+  - 'recordFromRep' needs the metadata for the keys in the 'Map'
+-------------------------------------------------------------------------------}
+
+-- | Push functor argument into 'Rep', so it can be operated on
+--
+-- The name is by analogy to @normalize@ in "Data.Record.Generic.Transform",
+-- although the details are different. In particular, 'normalizeRecordRep'
+-- is always safe, we do not need the equivalent of @HasNormalForm d x y@.
+normalizeRecordRep :: Rep I (Record f r) -> Rep f (Record I r)
+normalizeRecordRep = unsafeCoerce
+
+-- | Inverse to 'normalizeRecordRep'
+denormalizeRecordRep :: Rep f (Record I r) -> Rep I (Record f r)
+denormalizeRecordRep = unsafeCoerce
+
+-- | Generalization of 'recordToRep'
+recordToRep' :: forall f g r.
+     RecordMetadata r
+  => Record (f :.: g) r -> Rep f (Record g r)
+recordToRep' (MkR r) =
+    Rep.unsafeFromListAny $ Prelude.map aux names
+  where
+    names :: [String]
+    names = Rep.collapse $ recordFieldNames $ metadata (Proxy @(Record f r))
+
+    aux :: String -> f Any
+    aux nm = case Map.lookup nm r of
+               Just x  -> co x
+               Nothing -> error "impossible: non-existent field"
+
+    co :: (f :.: g) Any -> f Any
+    co = noInlineUnsafeCo
+
+-- | Generalization of 'recordFromRep'
+recordFromRep' :: forall f g r.
+     RecordMetadata r
+  => Rep f (Record g r) -> Record (f :.: g) r
+recordFromRep' =
+    MkR . Map.fromList . Prelude.zipWith aux names . Rep.toListAny
+  where
+    names :: [String]
+    names = Rep.collapse $ recordFieldNames $ metadata (Proxy @(Record f r))
+
+    aux :: String -> f Any -> (String, (f :.: g) Any)
+    aux name x = (name, co x)
+
+    co :: f Any -> (f :.: g) Any
+    co = noInlineUnsafeCo
+
+-- | Convert @Record f@ to @Rep I@
+recordToRep :: forall f r.
+     RecordMetadata r
+  => Record f r -> Rep I (Record f r)
+recordToRep = recordToRep' . co
+  where
+    co :: Record f r -> Record (I :.: f) r
+    co = noInlineUnsafeCo
+
+-- | Convert @Rep I@ to @Record f@
+recordFromRep :: forall f r.
+     RecordMetadata r
+  => Rep I (Record f r) -> Record f r
+recordFromRep = co . recordFromRep'
+  where
+    co :: Record (I :.: f) r -> Record f r
+    co = noInlineUnsafeCo
+
+-- | Convert @Record f@ to @Rep f@
+recordToNormalizedRep :: forall f r.
+     RecordMetadata r
+  => Record f r -> Rep f (Record I r)
+recordToNormalizedRep = normalizeRecordRep . recordToRep
+
+-- | Convert @Rep f@ to @Record f@
+recordFromNormalizedRep :: forall f r.
+     RecordMetadata r
+  => Rep f (Record I r) -> Record f r
+recordFromNormalizedRep = recordFromRep . denormalizeRecordRep
+
+{-------------------------------------------------------------------------------
   Generics
 -------------------------------------------------------------------------------}
 
-class RecordMetadata (f :: Type -> Type) (r :: [(Symbol, Type)]) where
-  recordMetadata :: Metadata (Record f r)
-
-class RecordMetadata f r => RecordConstraints f r c where
+class RecordMetadata r => RecordConstraints f r c where
   dictRecord :: Proxy c -> Rep (Dict c) (Record f r)
 
 type family RecordMetadataOf (f :: Type -> Type) (r :: [(Symbol, Type)]) :: [(Symbol, Type)]
   -- Rewritten by the plugin
 
-instance RecordMetadata f r => Generic (Record f r) where
-  type Constraints (Record f r) = RecordConstraints f r
+instance RecordMetadata r => Generic (Record f r) where
+  type Constraints (Record f r) = RecordConstraints f r -- RecordDictsF f r
   type MetadataOf  (Record f r) = RecordMetadataOf  f r
 
-  dict       = dictRecord
   metadata _ = recordMetadata
-
-  -- Implementation note: the order of the fields in the vector must match
-  -- the order as specified by the user in the type.
-  --
-  -- TODO: Can we avoid the O(n log n) cost?
-
-  from :: Record f r -> Rep I (Record f r)
-  from (MkR r) =
-      Rep.unsafeFromListAny $ Prelude.map aux names
-    where
-      names :: [String]
-      names = Rep.collapse $ recordFieldNames $ metadata (Proxy @(Record f r))
-
-      aux :: String -> I Any
-      aux nm = case Map.lookup nm r of
-                 Just x  -> I (co x)
-                 Nothing -> error "impossible: non-existent field"
-
-      co :: f Any -> Any
-      co = noInlineUnsafeCo
-
-  to :: Rep I (Record f r) -> Record f r
-  to =
-      MkR . Map.fromList . Prelude.zipWith aux names . Rep.toListAny
-    where
-      names :: [String]
-      names = Rep.collapse $ recordFieldNames $ metadata (Proxy @(Record f r))
-
-      aux :: String -> I Any -> (String, f Any)
-      aux name (I x) = (name, co x)
-
-      co :: Any -> f Any
-      co = noInlineUnsafeCo
+  from       = recordToRep
+  to         = recordFromRep
+  dict       = dictRecord      -- recordToRep' . recordDictsF
 
 {-------------------------------------------------------------------------------
   Instances
@@ -453,7 +648,7 @@ instance RecordConstraints f r FromJSON => FromJSON (Record f r) where
   Internal API
 -------------------------------------------------------------------------------}
 
--- | Used by the plugin during evidence construction for 'HasField'
+-- | Used by the plugin to construct evidence for 'HasField'
 --
 -- Precondition: the record must have the specified field with type @a@, (where
 -- @a@ will be of the form @f a'@ for some @a'). This precondition is verified
@@ -482,7 +677,9 @@ unsafeRecordHasField label (MkR r) = (
     co  = noInlineUnsafeCo
     co' = noInlineUnsafeCo
 
--- | Used by the plugin during evidence construction for 'RecordConstraints'
+-- | Used by the plugin to construct evidence for 'RecordConstraints'
+--
+-- TODO: Delete
 unsafeDictRecord :: forall f r c.
      [Dict c (f Any)]  -- ^ Dictionary for each field, in order
   -> Proxy c
@@ -492,11 +689,24 @@ unsafeDictRecord ds _ = Rep.unsafeFromListAny (Prelude.map co ds)
     co :: Dict c (f Any) -> Dict c Any
     co = noInlineUnsafeCo
 
--- | Used by the plugin during evidence construction for 'RecordMetadata'
-unsafeFieldMetadata :: forall f r.
-     [FieldMetadata (f Any)]
-  -> Rep FieldMetadata (Record f r)
-unsafeFieldMetadata = Rep.unsafeFromListAny . Prelude.map co
-  where
-    co :: FieldMetadata (f Any) -> FieldMetadata Any
-    co = noInlineUnsafeCo
+-- | Used by the plugin to construct evidence for 'RecordDicts'
+--
+-- Precondition: the list must have an entry for each field in the record,
+-- with an appropriate dictionary for that field.
+unsafeRecordDicts :: forall c r.
+     [(String, Dict c Any)]
+  -> Proxy c
+  -> Record (Dict c) r
+unsafeRecordDicts dicts _ = MkR $ Map.fromList dicts
+
+-- | Used by the plugin to construct evidence for 'RecordMetadata'
+unsafeRecordMetadata :: forall r.
+     [FieldMetadata Any]
+  -> Metadata (Record Irrelevant r)
+unsafeRecordMetadata fields = Metadata {
+      recordName          = "Record"
+    , recordConstructor   = "Record"
+    , recordSize          = length fields
+    , recordFieldMetadata = Rep.unsafeFromListAny fields
+    }
+

--- a/large-anon/src/Data/Record/Anonymous/Plugin/Constraints/HasField.hs
+++ b/large-anon/src/Data/Record/Anonymous/Plugin/Constraints/HasField.hs
@@ -114,7 +114,8 @@ evidenceHasField ::
   -> FastString -- ^ Field name (we cannot produce evidence for unknown fields)
   -> TcPluginM 'Solve EvTerm
 evidenceHasField ResolvedNames{..} CHasField{..} name = do
-    str <- mkStringExprFS name
+    str_expr <- mkStringExprFS name
+    let uniq_expr = mkFastStringUniqueIntExpr name
     return $
       evDataConApp
         (classDataCon clsHasField)
@@ -123,7 +124,8 @@ evidenceHasField ResolvedNames{..} CHasField{..} name = do
               Type hasFieldTypeFunctor
             , Type hasFieldTypeRecord
             , Type hasFieldTypeField
-            , str
+            , str_expr -- (useful to pass the string, for debugging)
+            , uniq_expr
             ]
         ]
 

--- a/large-anon/src/Data/Record/Anonymous/Plugin/Constraints/KnownFieldLabel.hs
+++ b/large-anon/src/Data/Record/Anonymous/Plugin/Constraints/KnownFieldLabel.hs
@@ -1,0 +1,78 @@
+{-# LANGUAGE DataKinds       #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Data.Record.Anonymous.Plugin.Constraints.KnownFieldLabel (
+    CKnownFieldLabel(..)
+  , parseKnownFieldLabel
+  , evidenceKnownFieldLabel
+  , solveKnownFieldLabel
+  ) where
+
+import Data.Void
+
+import Data.Record.Anonymous.Plugin.GhcTcPluginAPI
+import Data.Record.Anonymous.Plugin.NameResolution
+import Data.Record.Anonymous.Plugin.Parsing
+import Data.Record.Anonymous.Plugin.TyConSubst
+
+{-------------------------------------------------------------------------------
+  Definition
+-------------------------------------------------------------------------------}
+
+-- | Parsed form of an @KnownFieldLabel f@ constraint
+data CKnownFieldLabel = CKnownFieldLabel {
+      -- | The raw type argument to the @KnownFieldLabel@ constraint.
+      knownFieldType :: Type
+      -- | The underlying @FastString@ when the label is a literal.
+    , knownFieldLabel :: FastString
+    }
+
+{-------------------------------------------------------------------------------
+  Outputable
+-------------------------------------------------------------------------------}
+
+instance Outputable CKnownFieldLabel where
+  ppr (CKnownFieldLabel _ field) = parens $
+          text "CKnownFieldLabel"
+      <+> ppr field
+
+{-------------------------------------------------------------------------------
+  Parser
+-------------------------------------------------------------------------------}
+
+parseKnownFieldLabel ::
+     TyConSubst
+  -> ResolvedNames
+  -> Ct
+  -> ParseResult Void (GenLocated CtLoc CKnownFieldLabel)
+parseKnownFieldLabel _ ResolvedNames{..} =
+    parseConstraint' clsKnownFieldLabel $ \[ty] -> do
+      fld <- isStrLitTy ty
+      return $ CKnownFieldLabel {
+            knownFieldType  = ty
+          , knownFieldLabel = fld
+          }
+
+{-------------------------------------------------------------------------------
+  Evidence
+-------------------------------------------------------------------------------}
+
+evidenceKnownFieldLabel :: ResolvedNames -> CKnownFieldLabel -> EvExpr
+evidenceKnownFieldLabel ResolvedNames{..} CKnownFieldLabel{..} =
+    mkCoreConApps
+      (classDataCon clsKnownFieldLabel)
+      [ Type knownFieldType
+      , mkFastStringUniqueIntExpr knownFieldLabel ]
+
+{-------------------------------------------------------------------------------
+  Solver
+-------------------------------------------------------------------------------}
+
+solveKnownFieldLabel ::
+     ResolvedNames
+  -> Ct
+  -> GenLocated CtLoc CKnownFieldLabel
+  -> TcPluginM 'Solve (Maybe (EvTerm, Ct), [Ct])
+solveKnownFieldLabel rn orig (L _ lbl) = do
+  let ev = evidenceKnownFieldLabel rn lbl
+  return (Just (EvExpr ev, orig), [])

--- a/large-anon/src/Data/Record/Anonymous/Plugin/Constraints/RecordConstraints.hs
+++ b/large-anon/src/Data/Record/Anonymous/Plugin/Constraints/RecordConstraints.hs
@@ -164,9 +164,7 @@ solveRecordConstraints rn@ResolvedNames{clsRecordMetadata}
         evMeta  <- newWanted loc $
                      mkClassPred
                        clsRecordMetadata
-                       [ recordConstraintsTypeFunctor
-                       , recordConstraintsTypeRecord
-                       ]
+                       [recordConstraintsTypeRecord]
         fields' <- knownRecordTraverse fields $ \fld ->
                      newWanted loc $
                        mkAppTy

--- a/large-anon/src/Data/Record/Anonymous/Plugin/Constraints/RecordDicts.hs
+++ b/large-anon/src/Data/Record/Anonymous/Plugin/Constraints/RecordDicts.hs
@@ -94,7 +94,7 @@ evidenceRecordDicts ResolvedNames{..} CRecordDicts{..} fields = do
         [ mkCoreApps (Var idUnsafeRecordDicts) [
               Type recordDictsTypeConstraint
             , Type recordDictsTypeFields
-            , mkListExpr (mkTupleTy Boxed [stringTy, dictType]) fields'
+            , mkListExpr (mkTupleTy Boxed [intTy, dictType]) fields'
             ]
         ]
   where
@@ -110,9 +110,8 @@ evidenceRecordDicts ResolvedNames{..} CRecordDicts{..} fields = do
                            , knownFieldType = fieldType
                            , knownFieldInfo = dict
                            } = do
-        str <- mkStringExprFS name
         return $ mkCoreTup [
-            str
+            mkFastStringUniqueIntExpr name
           , mkCoreConApps dataConDict [
                 Type liftedTypeKind
               , Type recordDictsTypeConstraint

--- a/large-anon/src/Data/Record/Anonymous/Plugin/Constraints/RecordDicts.hs
+++ b/large-anon/src/Data/Record/Anonymous/Plugin/Constraints/RecordDicts.hs
@@ -1,0 +1,161 @@
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Data.Record.Anonymous.Plugin.Constraints.RecordDicts (
+    CRecordDicts(..)
+  , parseRecordDicts
+  , solveRecordDicts
+  ) where
+
+import Data.Foldable (toList)
+import Data.Void
+
+import Data.Record.Anonymous.Plugin.GhcTcPluginAPI
+import Data.Record.Anonymous.Plugin.NameResolution
+import Data.Record.Anonymous.Plugin.Parsing
+import Data.Record.Anonymous.Plugin.Record
+import Data.Record.Anonymous.Plugin.TyConSubst
+
+{-------------------------------------------------------------------------------
+  Definition
+-------------------------------------------------------------------------------}
+
+-- | Parsed form of @RecordDicts c r@
+data CRecordDicts = CRecordDicts {
+      -- | Fields of the record (parsed form of @r@)
+      recordDictsFields :: Fields
+
+      -- | Raw arguments to @RecordDicts@ (for evidence construction)
+    , recordDictsTypeRaw :: [Type]
+
+      -- | Type of the fields (@r@)
+    , recordDictsTypeFields :: Type
+
+      -- | Constraint required for each field (@c@)
+    , recordDictsTypeConstraint :: Type
+    }
+
+{-------------------------------------------------------------------------------
+  Outputable
+-------------------------------------------------------------------------------}
+
+instance Outputable CRecordDicts where
+  ppr (CRecordDicts fields typeRaw typeConstraint typeFields) = parens $
+      text "CRecordDicts" <+> braces (vcat [
+          text "recordDictsFields"         <+> text "=" <+> ppr fields
+        , text "recordDictsTypeRaw"        <+> text "=" <+> ppr typeRaw
+        , text "recordDictsTypeFields    " <+> text "=" <+> ppr typeFields
+        , text "recordDictsTypeConstraint" <+> text "=" <+> ppr typeConstraint
+        ])
+
+{-------------------------------------------------------------------------------
+  Parser
+-------------------------------------------------------------------------------}
+
+parseRecordDicts ::
+     TyConSubst
+  -> ResolvedNames
+  -> Ct
+  -> ParseResult Void (GenLocated CtLoc CRecordDicts)
+parseRecordDicts tcs rn@ResolvedNames{..} =
+    parseConstraint' clsRecordDicts $ \case
+      args@[r, c] -> do
+        fields <- parseFields tcs rn r
+        return CRecordDicts {
+            recordDictsFields         = fields
+          , recordDictsTypeRaw        = args
+          , recordDictsTypeFields     = r
+          , recordDictsTypeConstraint = c
+          }
+      _invalidNumArgs ->
+        Nothing
+
+{-------------------------------------------------------------------------------
+  Evidence
+-------------------------------------------------------------------------------}
+
+-- | Construct evidence
+--
+-- For each field we need an evidence variable corresponding to the evidence
+-- that that fields satisfies the constraint.
+evidenceRecordDicts ::
+     ResolvedNames
+  -> CRecordDicts
+  -> KnownRecord EvVar
+  -> TcPluginM 'Solve EvTerm
+evidenceRecordDicts ResolvedNames{..} CRecordDicts{..} fields = do
+    fields' <- mapM dictForField (knownRecordFields fields)
+    return $
+      evDataConApp
+        (classDataCon clsRecordDicts)
+        recordDictsTypeRaw
+        [ mkCoreApps (Var idUnsafeRecordDicts) [
+              Type recordDictsTypeConstraint
+            , Type recordDictsTypeFields
+            , mkListExpr (mkTupleTy Boxed [stringTy, dictType]) fields'
+            ]
+        ]
+  where
+    dictType :: Type
+    dictType = mkTyConApp tyConDict [
+          liftedTypeKind
+        , recordDictsTypeConstraint
+        , anyType
+        ]
+
+    dictForField :: KnownField EvVar -> TcPluginM 'Solve EvExpr
+    dictForField KnownField{ knownFieldName = name
+                           , knownFieldType = fieldType
+                           , knownFieldInfo = dict
+                           } = do
+        str <- mkStringExprFS name
+        return $ mkCoreTup [
+            str
+          , mkCoreConApps dataConDict [
+                Type liftedTypeKind
+              , Type recordDictsTypeConstraint
+              , Type anyType
+              , mkCoreApps (Var idUnsafeCoerce) [
+                    Type $ mkAppTy recordDictsTypeConstraint fieldType
+                  , Type $ mkAppTy recordDictsTypeConstraint anyType
+                  , Var dict
+                  ]
+              ]
+          ]
+
+    -- Any at kind Type
+    anyType :: Type
+    anyType = mkTyConApp anyTyCon [liftedTypeKind]
+
+{-------------------------------------------------------------------------------
+  Solver
+-------------------------------------------------------------------------------}
+
+solveRecordDicts ::
+     ResolvedNames
+  -> Ct
+  -> GenLocated CtLoc CRecordDicts
+  -> TcPluginM 'Solve (Maybe (EvTerm, Ct), [Ct])
+solveRecordDicts rn orig (L loc cr@CRecordDicts{..}) = do
+    case checkAllFieldsKnown recordDictsFields of
+      Nothing ->
+        return (Nothing, [])
+      Just fields -> do
+        fields' :: KnownRecord CtEvidence
+           <- knownRecordTraverse fields $ \fld ->
+                newWanted loc $
+                  mkAppTy recordDictsTypeConstraint (knownFieldType fld)
+        ev <- evidenceRecordDicts rn cr $getEvVar <$> fields'
+        return (
+            Just (ev, orig)
+          , map mkNonCanonical (toList fields')
+          )
+  where
+    getEvVar :: CtEvidence -> EvVar
+    getEvVar ct = case ctev_dest ct of
+      EvVarDest var -> var
+      HoleDest  _   -> error "impossible (we don't ask for primitive equality)"
+
+

--- a/large-anon/src/Data/Record/Anonymous/Plugin/GhcTcPluginAPI.hs
+++ b/large-anon/src/Data/Record/Anonymous/Plugin/GhcTcPluginAPI.hs
@@ -20,6 +20,7 @@ module Data.Record.Anonymous.Plugin.GhcTcPluginAPI (
 
     -- * Additional exports
   , splitAppTys
+  , mkFastStringUniqueIntExpr
 
     -- * New functonality
   , isCanonicalVarEq
@@ -39,21 +40,25 @@ import GHC.Utils.Outputable
 #if __GLASGOW_HASKELL__ >= 808 &&  __GLASGOW_HASKELL__ < 810
 import TcRnTypes (Ct(..))
 import Type (splitAppTys)
+import FastString (FastString(..), mkFastString)
 #endif
 
 #if __GLASGOW_HASKELL__ >= 810 &&  __GLASGOW_HASKELL__ < 900
 import Constraint (Ct(..))
 import Type (splitAppTys)
+import FastString (FastString(..), mkFastString)
 #endif
 
 #if __GLASGOW_HASKELL__ >= 900 &&  __GLASGOW_HASKELL__ < 902
 import GHC.Core.Type (splitAppTys)
 import GHC.Tc.Types.Constraint (Ct(..))
+import GHC.Data.FastString (FastString(..), mkFastString)
 #endif
 
 #if __GLASGOW_HASKELL__ >= 902
 import GHC.Core.Type (splitAppTys)
 import GHC.Tc.Types.Constraint (Ct(..), CanEqLHS(..))
+import GHC.Data.FastString (FastString(..), mkFastString)
 #endif
 
 isCanonicalVarEq :: Ct -> Maybe (TcTyVar, Type)
@@ -88,3 +93,7 @@ instance Outputable a => Outputable (NonEmpty a) where
 instance (Outputable l, Outputable e) => Outputable (GenLocated l e) where
   ppr (L l e) = parens $ text "L" <+> ppr l <+> ppr e
 #endif
+
+mkFastStringUniqueIntExpr :: FastString -> CoreExpr
+mkFastStringUniqueIntExpr fs =
+  mkUncheckedIntExpr $ fromIntegral (uniq fs)

--- a/large-anon/src/Data/Record/Anonymous/Plugin/NameResolution.hs
+++ b/large-anon/src/Data/Record/Anonymous/Plugin/NameResolution.hs
@@ -15,12 +15,13 @@ data ResolvedNames = ResolvedNames {
       clsHasField            :: Class
     , clsIsomorphic          :: Class
     , clsKnownSymbol         :: Class
+    , clsKnownFieldLabel     :: Class
     , clsRecordConstraints   :: Class -- TODO: remove
     , clsRecordDicts         :: Class
     , clsRecordMetadata      :: Class
     , dataConDict            :: DataCon
     , dataConFieldLazy       :: DataCon
-    , dataConFieldMetadata   :: DataCon
+    , dataConFieldMetadata'  :: DataCon
     , dataConProxy           :: DataCon
     , idUnsafeCoerce         :: Id
     , idUnsafeDictRecord     :: Id
@@ -28,7 +29,7 @@ data ResolvedNames = ResolvedNames {
     , idUnsafeRecordHasField :: Id
     , idUnsafeRecordMetadata :: Id
     , tyConDict              :: TyCon
-    , tyConFieldMetadata     :: TyCon
+    , tyConFieldMetadata'    :: TyCon
     , tyConMerge             :: TyCon
     , tyConRecord            :: TyCon
     , tyConRecordMetadataOf  :: TyCon
@@ -47,14 +48,15 @@ nameResolution = do
     clsHasField          <- getClass grc  "HasField"
     clsIsomorphic        <- getClass drai "Isomorphic"
     clsKnownSymbol       <- tcLookupClass knownSymbolClassName
+    clsKnownFieldLabel   <- getClass drai "KnownFieldLabel"
     clsRecordConstraints <- getClass drai "RecordConstraints"
     clsRecordDicts       <- getClass drai "RecordDicts"
     clsRecordMetadata    <- getClass drai "RecordMetadata"
 
-    dataConDict          <- getDataCon dsd "Dict"
-    dataConFieldLazy     <- getDataCon drg "FieldLazy"
-    dataConFieldMetadata <- getDataCon drg "FieldMetadata"
-    dataConProxy         <- getDataCon dp  "Proxy"
+    dataConDict           <- getDataCon dsd  "Dict"
+    dataConFieldLazy      <- getDataCon drg  "FieldLazy"
+    dataConFieldMetadata' <- getDataCon drai "FieldMetadata'"
+    dataConProxy          <- getDataCon dp   "Proxy"
 
     idUnsafeCoerce         <- getVar uc   "unsafeCoerce"
     idUnsafeDictRecord     <- getVar drai "unsafeDictRecord"
@@ -63,7 +65,7 @@ nameResolution = do
     idUnsafeRecordMetadata <- getVar drai "unsafeRecordMetadata"
 
     tyConDict             <- getTyCon dsd  "Dict"
-    tyConFieldMetadata    <- getTyCon drg  "FieldMetadata"
+    tyConFieldMetadata'   <- getTyCon drai "FieldMetadata'"
     tyConMerge            <- getTyCon drai "Merge"
     tyConRecord           <- getTyCon drai "Record"
     tyConRecordMetadataOf <- getTyCon drai "RecordMetadataOf"

--- a/large-anon/src/Data/Record/Anonymous/Plugin/NameResolution.hs
+++ b/large-anon/src/Data/Record/Anonymous/Plugin/NameResolution.hs
@@ -15,17 +15,18 @@ data ResolvedNames = ResolvedNames {
       clsHasField            :: Class
     , clsIsomorphic          :: Class
     , clsKnownSymbol         :: Class
-    , clsRecordConstraints   :: Class
+    , clsRecordConstraints   :: Class -- TODO: remove
+    , clsRecordDicts         :: Class
     , clsRecordMetadata      :: Class
     , dataConDict            :: DataCon
     , dataConFieldLazy       :: DataCon
     , dataConFieldMetadata   :: DataCon
-    , dataConMetadata        :: DataCon
     , dataConProxy           :: DataCon
     , idUnsafeCoerce         :: Id
     , idUnsafeDictRecord     :: Id
-    , idUnsafeFieldMetadata  :: Id
+    , idUnsafeRecordDicts    :: Id
     , idUnsafeRecordHasField :: Id
+    , idUnsafeRecordMetadata :: Id
     , tyConDict              :: TyCon
     , tyConFieldMetadata     :: TyCon
     , tyConMerge             :: TyCon
@@ -47,18 +48,19 @@ nameResolution = do
     clsIsomorphic        <- getClass drai "Isomorphic"
     clsKnownSymbol       <- tcLookupClass knownSymbolClassName
     clsRecordConstraints <- getClass drai "RecordConstraints"
+    clsRecordDicts       <- getClass drai "RecordDicts"
     clsRecordMetadata    <- getClass drai "RecordMetadata"
 
     dataConDict          <- getDataCon dsd "Dict"
     dataConFieldLazy     <- getDataCon drg "FieldLazy"
     dataConFieldMetadata <- getDataCon drg "FieldMetadata"
-    dataConMetadata      <- getDataCon drg "Metadata"
     dataConProxy         <- getDataCon dp  "Proxy"
 
     idUnsafeCoerce         <- getVar uc   "unsafeCoerce"
     idUnsafeDictRecord     <- getVar drai "unsafeDictRecord"
-    idUnsafeFieldMetadata  <- getVar drai "unsafeFieldMetadata"
+    idUnsafeRecordDicts    <- getVar drai "unsafeRecordDicts"
     idUnsafeRecordHasField <- getVar drai "unsafeRecordHasField"
+    idUnsafeRecordMetadata <- getVar drai "unsafeRecordMetadata"
 
     tyConDict             <- getTyCon dsd  "Dict"
     tyConFieldMetadata    <- getTyCon drg  "FieldMetadata"

--- a/large-anon/src/Data/Record/Anonymous/Plugin/Solver.hs
+++ b/large-anon/src/Data/Record/Anonymous/Plugin/Solver.hs
@@ -11,6 +11,7 @@ import Data.Traversable (forM)
 
 import Data.Record.Anonymous.Plugin.Constraints.HasField
 import Data.Record.Anonymous.Plugin.Constraints.Isomorphic
+import Data.Record.Anonymous.Plugin.Constraints.KnownFieldLabel
 import Data.Record.Anonymous.Plugin.Constraints.RecordConstraints
 import Data.Record.Anonymous.Plugin.Constraints.RecordDicts
 import Data.Record.Anonymous.Plugin.Constraints.RecordMetadata
@@ -33,6 +34,7 @@ solve rn given wanted =
          , forM parsedRecordDicts       $ uncurry (solveRecordDicts       rn)
          , forM parsedRecordMetadata    $ uncurry (solveRecordMetadata    rn)
          , forM parsedIsomorphic        $ uncurry (solveIsomorphic        rn)
+         , forM parsedKnownFieldLabel   $ uncurry (solveKnownFieldLabel   rn)
          ]
        return $ TcPluginOk solved new
   where
@@ -44,6 +46,7 @@ solve rn given wanted =
     parsedRecordDicts       :: [(Ct, GenLocated CtLoc CRecordDicts)]
     parsedRecordMetadata    :: [(Ct, GenLocated CtLoc CRecordMetadata)]
     parsedIsomorphic        :: [(Ct, GenLocated CtLoc CIsomorphic)]
+    parsedKnownFieldLabel   :: [(Ct, GenLocated CtLoc CKnownFieldLabel)]
 
     parsedHasField =
         parseAll' (withOrig (parseHasField tcs rn)) wanted
@@ -55,6 +58,8 @@ solve rn given wanted =
         parseAll' (withOrig (parseRecordMetadata tcs rn)) wanted
     parsedIsomorphic =
         parseAll' (withOrig (parseIsomorphic tcs rn)) wanted
+    parsedKnownFieldLabel =
+        parseAll' (withOrig (parseKnownFieldLabel tcs rn)) wanted
 
     _debugInput :: String
     _debugInput = unlines [
@@ -91,6 +96,10 @@ solve rn given wanted =
         , concat [
               "parsedIsomorphic: "
             , showSDocUnsafe (ppr parsedIsomorphic)
+            ]
+        , concat [
+              "parsedKnownFieldLabel: "
+            , showSDocUnsafe (ppr parsedKnownFieldLabel)
             ]
         , concat [
               "tcs (TyConSubst): "

--- a/large-anon/src/Data/Record/Anonymous/Plugin/Solver.hs
+++ b/large-anon/src/Data/Record/Anonymous/Plugin/Solver.hs
@@ -12,6 +12,7 @@ import Data.Traversable (forM)
 import Data.Record.Anonymous.Plugin.Constraints.HasField
 import Data.Record.Anonymous.Plugin.Constraints.Isomorphic
 import Data.Record.Anonymous.Plugin.Constraints.RecordConstraints
+import Data.Record.Anonymous.Plugin.Constraints.RecordDicts
 import Data.Record.Anonymous.Plugin.Constraints.RecordMetadata
 import Data.Record.Anonymous.Plugin.GhcTcPluginAPI
 import Data.Record.Anonymous.Plugin.NameResolution
@@ -29,6 +30,7 @@ solve rn given wanted =
     do (solved, new) <- fmap (bimap catMaybes concat . unzip) $ concatM [
            forM parsedHasField          $ uncurry (solveHasField          rn)
          , forM parsedRecordConstraints $ uncurry (solveRecordConstraints rn)
+         , forM parsedRecordDicts       $ uncurry (solveRecordDicts       rn)
          , forM parsedRecordMetadata    $ uncurry (solveRecordMetadata    rn)
          , forM parsedIsomorphic        $ uncurry (solveIsomorphic        rn)
          ]
@@ -39,6 +41,7 @@ solve rn given wanted =
 
     parsedHasField          :: [(Ct, GenLocated CtLoc CHasField)]
     parsedRecordConstraints :: [(Ct, GenLocated CtLoc CRecordConstraints)]
+    parsedRecordDicts       :: [(Ct, GenLocated CtLoc CRecordDicts)]
     parsedRecordMetadata    :: [(Ct, GenLocated CtLoc CRecordMetadata)]
     parsedIsomorphic        :: [(Ct, GenLocated CtLoc CIsomorphic)]
 
@@ -46,6 +49,8 @@ solve rn given wanted =
         parseAll' (withOrig (parseHasField tcs rn)) wanted
     parsedRecordConstraints =
         parseAll' (withOrig (parseRecordConstraints tcs rn)) wanted
+    parsedRecordDicts =
+        parseAll' (withOrig (parseRecordDicts tcs rn)) wanted
     parsedRecordMetadata =
         parseAll' (withOrig (parseRecordMetadata tcs rn)) wanted
     parsedIsomorphic =
@@ -74,6 +79,10 @@ solve rn given wanted =
         , concat [
               "parsedRecordConstraints: "
             , showSDocUnsafe (ppr parsedRecordConstraints)
+            ]
+        , concat [
+              "parsedRecordDicts: "
+            , showSDocUnsafe (ppr parsedRecordDicts)
             ]
         , concat [
               "parsedRecordMetadata: "

--- a/large-anon/test/Test/Record/Anonymous/Prop/Combinators/Constrained.hs
+++ b/large-anon/test/Test/Record/Anonymous/Prop/Combinators/Constrained.hs
@@ -1,0 +1,8 @@
+module Test.Record.Anonymous.Prop.Combinators.Constrained (tests) where
+
+import Test.Tasty
+
+tests :: TestTree
+tests = testGroup "" [
+    ]
+

--- a/large-anon/test/Test/Record/Anonymous/Prop/Model/Generator.hs
+++ b/large-anon/test/Test/Record/Anonymous/Prop/Model/Generator.hs
@@ -66,19 +66,13 @@ data SomeRecordPair f g where
 
 someModlRecord ::
      SomeFields
-  -> ( forall r.
-            SListI (Types r)
-         => ModelFields r -> ModelRecord f r
-     )
+  -> (forall r. SListI (Types r) => ModelFields r -> ModelRecord f r)
   -> SomeRecord f
 someModlRecord (SF mf) f = SR mf (f mf)
 
 someAnonRecord :: forall f.
      SomeFields
-  -> ( forall r.
-            RecordMetadata f r
-         => Record f r
-     )
+  -> (forall r. RecordMetadata r => Record f r)
   -> SomeRecord f
 someAnonRecord (SF mf) f = SR mf (Model.fromRecord mf $ f' mf)
   where

--- a/large-anon/test/Test/Record/Anonymous/Sanity/HasField.hs
+++ b/large-anon/test/Test/Record/Anonymous/Sanity/HasField.hs
@@ -1,0 +1,51 @@
+{-# LANGUAGE DataKinds        #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE TypeApplications #-}
+
+{-# OPTIONS_GHC -fplugin=Data.Record.Anonymous.Plugin #-}
+
+module Test.Record.Anonymous.Sanity.HasField (tests) where
+
+import Data.SOP.BasicFunctors -- TODO: Should this be exported from large-anon?
+
+import Data.Record.Anonymous (Record)
+import qualified Data.Record.Anonymous as Anon
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+tests :: TestTree
+tests = testGroup "Test.Record.Anonymous.Sanity.HasField" [
+      testCase "HasField" test_HasField
+    ]
+
+{-------------------------------------------------------------------------------
+  Example values
+-------------------------------------------------------------------------------}
+
+record1 :: Record I '[ '("x", Bool), '("y", Char), '("z", ()) ]
+record1 =
+      Anon.insert #x (I True)
+    $ Anon.insert #y (I 'a')
+    $ Anon.insert #z (I ())
+    $ Anon.empty
+
+{-------------------------------------------------------------------------------
+  Tests proper
+-------------------------------------------------------------------------------}
+
+test_HasField :: Assertion
+test_HasField = do
+    assertEqual "get field 1" (I True) $ (Anon.get #x record1)
+    assertEqual "get field 2" (I 'a')  $ (Anon.get #y record1)
+    assertEqual "get field 3" (I ())   $ (Anon.get #z record1)
+
+    -- TODO: We should do whole-record comparisons, but for that we need
+    -- Show and Eq instances, which will depend on generics
+
+    assertEqual "set field 1, then get field 1" (I False) $
+      Anon.get #x (Anon.set #x (I False) record1)
+    assertEqual "set field 1, then get field 2" (I 'a') $
+      (Anon.get #y (Anon.set #x (I False) record1))
+
+    -- TODO: think about and test what happens with duplicate labels

--- a/large-anon/test/Test/Record/Anonymous/Sanity/RecordDicts.hs
+++ b/large-anon/test/Test/Record/Anonymous/Sanity/RecordDicts.hs
@@ -1,0 +1,74 @@
+{-# LANGUAGE DataKinds        #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE TypeApplications #-}
+
+{-# OPTIONS_GHC -fplugin=Data.Record.Anonymous.Plugin #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Test.Record.Anonymous.Sanity.RecordDicts (tests) where
+
+import Data.Record.Anonymous
+
+import qualified Data.Record.Anonymous as Anon
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+tests :: TestTree
+tests = testGroup "Test.Record.Anonymous.Sanity.RecordDicts" [
+      testCase "manual"  test_manual
+    , testCase "derived" test_derived
+    ]
+
+{-------------------------------------------------------------------------------
+  Example value
+-------------------------------------------------------------------------------}
+
+recordA :: Record I '[ '("a", Int), '("b", Bool), '("c", Char) ]
+recordA =
+      insert #a (I 1)
+    $ insert #b (I True)
+    $ insert #c (I 'a')
+    $ empty
+
+-- | Manually created record of dictionaries
+--
+-- Normally this record would be constructed by the plugin (for 'RecordDicts'
+-- instance).
+recordD :: Record (Dict Show :.: I) '[ '("a", Int), '("b", Bool), '("c", Char) ]
+recordD =
+      insert #a (Comp Dict)
+    $ insert #b (Comp Dict)
+    $ insert #c (Comp Dict)
+    $ empty
+
+{-------------------------------------------------------------------------------
+  Auxiliary
+-------------------------------------------------------------------------------}
+
+showFields :: Record (Dict Show :.: f) r -> Record f r -> [String]
+showFields ds xs = Anon.collapse $ Anon.zipWith aux ds xs
+  where
+    aux :: (Dict Show :.: f) x -> f x -> K String x
+    aux (Comp Dict) x = K (show x)
+
+{-------------------------------------------------------------------------------
+  Tests proper
+-------------------------------------------------------------------------------}
+
+-- | Test with manually constructed record-of-dictionaries
+--
+-- Just a sanity check on the sanity check that the test makes sense.
+test_manual :: Assertion
+test_manual = do
+     assertEqual "" expected $ showFields recordD recordA
+  where
+    expected :: [String]
+    expected = ["I 1", "I True", "I 'a'"]
+
+test_derived :: Assertion
+test_derived = do
+     assertEqual "" expected $ showFields (recordDictsF (Proxy @Show)) recordA
+  where
+    expected :: [String]
+    expected = ["I 1", "I True", "I 'a'"]

--- a/large-anon/test/TestLargeAnon.hs
+++ b/large-anon/test/TestLargeAnon.hs
@@ -2,23 +2,29 @@ module Main (main) where
 
 import Test.Tasty
 
-import qualified Test.Record.Anonymous.Sanity.Basics
+import qualified Test.Record.Anonymous.Sanity.HasField
+import qualified Test.Record.Anonymous.Sanity.Generics
 import qualified Test.Record.Anonymous.Sanity.Merging
 import qualified Test.Record.Anonymous.Sanity.Casting
 import qualified Test.Record.Anonymous.Sanity.DuplicateFields
 import qualified Test.Record.Anonymous.Sanity.TypeLevelMetadata
+import qualified Test.Record.Anonymous.Sanity.RecordDicts
 import qualified Test.Record.Anonymous.Prop.Combinators.Simple
+import qualified Test.Record.Anonymous.Prop.Combinators.Constrained
 
 main :: IO ()
 main = defaultMain $ testGroup "large-anon" [
       testGroup "Sanity" [
-          Test.Record.Anonymous.Sanity.Basics.tests
+          Test.Record.Anonymous.Sanity.HasField.tests
+        , Test.Record.Anonymous.Sanity.Generics.tests
         , Test.Record.Anonymous.Sanity.Merging.tests
         , Test.Record.Anonymous.Sanity.Casting.tests
         , Test.Record.Anonymous.Sanity.DuplicateFields.tests
         , Test.Record.Anonymous.Sanity.TypeLevelMetadata.tests
+        , Test.Record.Anonymous.Sanity.RecordDicts.tests
         ]
     , testGroup "Prop" [
           Test.Record.Anonymous.Prop.Combinators.Simple.tests
+        , Test.Record.Anonymous.Prop.Combinators.Constrained.tests
         ]
     ]

--- a/large-generics/src/Data/Record/Generic.hs
+++ b/large-generics/src/Data/Record/Generic.hs
@@ -1,9 +1,12 @@
-{-# LANGUAGE DataKinds          #-}
-{-# LANGUAGE ExplicitNamespaces #-}
-{-# LANGUAGE FlexibleInstances  #-}
-{-# LANGUAGE GADTs              #-}
-{-# LANGUAGE KindSignatures     #-}
-{-# LANGUAGE TypeFamilies       #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE ExplicitNamespaces  #-}
+{-# LANGUAGE FlexibleInstances   #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE KindSignatures      #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE TypeFamilies        #-}
 
 module Data.Record.Generic (
     -- * Types with a generic view


### PR DESCRIPTION
I wanted to experiment with making the internal representation use `IntMap (f Any)` instead of a `Map String (f Any)`. I don't think there's any way you can recover the unique from a `KnownSymbol` instance, so I added a new class `KnownFieldLabel` which allows us to compute the `Unique` from the field label, and solve it in the plugin.

Unfortunately I had to change `large-generics` (and not just `large-anon`), to add a `KnownFieldLabel` context to `FieldMetadata`. I couldn't get the `Generic` instance to work changing only `large-anon`.