### PR TITLE
Simple combinators

### DIFF
--- a/large-anon/large-anon.cabal
+++ b/large-anon/large-anon.cabal
@@ -70,6 +70,10 @@ test-suite test-large-anon
   main-is:
       TestLargeAnon.hs
   other-modules:
+      Test.Record.Anonymous.Prop.Combinators.Simple
+      Test.Record.Anonymous.Prop.Model
+      Test.Record.Anonymous.Prop.Model.Generator
+      Test.Record.Anonymous.Prop.Model.Orphans
       Test.Record.Anonymous.Sanity.Basics
       Test.Record.Anonymous.Sanity.Casting
       Test.Record.Anonymous.Sanity.DuplicateFields
@@ -81,8 +85,11 @@ test-suite test-large-anon
       base
     , aeson
     , large-anon
+    , mtl
+    , QuickCheck
     , tasty
     , tasty-hunit
+    , tasty-quickcheck
 
       -- TODO: The dependencies below are unfortunate, and /should/ not be
       -- necessary: users should not have to declare dependencies on

--- a/large-anon/src/Data/Record/Anonymous.hs
+++ b/large-anon/src/Data/Record/Anonymous.hs
@@ -19,6 +19,21 @@ module Data.Record.Anonymous (
   , get
   , set
   , describeRecord
+    -- * Combinators
+    -- ** "Functor"
+  , map
+  , mapM
+    -- ** Zipping
+  , zip
+  , zipWith
+  , zipWithM
+    -- ** "Foldable"
+  , collapse
+    -- ** "Traversable"
+  , sequenceA
+    -- ** "Applicative"
+  , pure
+  , ap
     -- * Generics
   , RecordConstraints(..)
   , RecordMetadata(..)
@@ -27,6 +42,8 @@ module Data.Record.Anonymous (
   , module GHC.Records.Compat
   , module Data.Record.Generic
   ) where
+
+import Prelude hiding (map, mapM, zip, zipWith, sequenceA, pure)
 
 import Data.List (intercalate)
 import Data.Proxy

--- a/large-anon/test/Test/Record/Anonymous/Prop/Combinators/Simple.hs
+++ b/large-anon/test/Test/Record/Anonymous/Prop/Combinators/Simple.hs
@@ -1,0 +1,135 @@
+{-# LANGUAGE GADTs         #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE ViewPatterns  #-}
+
+module Test.Record.Anonymous.Prop.Combinators.Simple (tests) where
+
+import Control.Monad.State
+import Data.Bifunctor
+import Data.SOP
+
+import qualified Data.Record.Anonymous as Anon
+
+import Test.Tasty
+import Test.Tasty.QuickCheck
+
+import Test.Record.Anonymous.Prop.Model.Orphans ()
+import Test.Record.Anonymous.Prop.Model.Generator
+
+import qualified Test.Record.Anonymous.Prop.Model as Modl
+
+tests :: TestTree
+tests = testGroup "Test.Record.Anonymous.Prop.Combinators.Simple" [
+      testProperty "map"       test_map
+    , testProperty "mapM"      test_mapM
+    , testProperty "zip"       test_zip
+    , testProperty "zipWith"   test_zipWith
+    , testProperty "zipWithM"  test_zipWithM
+    , testProperty "collapse"  test_collapse
+    , testProperty "sequenceA" test_sequenceA
+    , testProperty "pure"      test_pure
+    , testProperty "ap"        test_ap
+    ]
+
+{-------------------------------------------------------------------------------
+  Tests proper
+-------------------------------------------------------------------------------}
+
+test_map ::
+     SomeRecord (K Int)
+  -> Fun Int Int
+  -> Property
+test_map r (applyFun -> f) =
+        onModlRecord (Modl.map f') r
+    === onAnonRecord (Anon.map f') r
+  where
+    f' :: K Int x -> K Int x
+    f' = mapKK f
+
+test_mapM ::
+     SomeRecord (K Int)
+  -> Fun (Int, Word) (Int, Word)
+  -> Property
+test_mapM r (applyFun -> f) =
+        (run $ onModlRecordM (Modl.mapM f') r)
+    === (run $ onAnonRecordM (Anon.mapM f') r)
+  where
+    run :: State Word a -> a
+    run = flip evalState 0
+
+    f' :: K Int x -> State Word (K Int x)
+    f' (K x) = state $ \s -> first K $ f (x, s)
+
+test_zip ::
+     SomeRecordPair (K Int) (K Int)
+  -> Property
+test_zip r =
+        onModlRecordPair Modl.zip r
+    === onAnonRecordPair Anon.zip r
+
+test_zipWith ::
+     SomeRecordPair (K Int) (K Int)
+  -> Fun (Int, Int) Int
+  -> Property
+test_zipWith r (applyFun -> f) =
+        onModlRecordPair (Modl.zipWith f') r
+    === onAnonRecordPair (Anon.zipWith f') r
+  where
+    f' :: K Int x -> K Int x -> K Int x
+    f' (K x) (K y) = K $ f (x, y)
+
+test_zipWithM ::
+     SomeRecordPair (K Int) (K Int)
+  -> Fun (Int, Int, Word) (Int, Word)
+  -> Property
+test_zipWithM r (applyFun -> f) =
+        (run $ onModlRecordPairM (Modl.zipWithM f') r)
+    === (run $ onAnonRecordPairM (Anon.zipWithM f') r)
+  where
+    run :: State Word a -> a
+    run = flip evalState 0
+
+    f' :: K Int x -> K Int x -> State Word (K Int x)
+    f' (K x) (K y) = state $ \s -> first K $ f (x, y, s)
+
+test_collapse ::
+     SomeRecord (K Int)
+  -> Property
+test_collapse (SR mf r) =
+        Modl.collapse r
+    === Anon.collapse (Modl.toRecord mf r)
+
+test_sequenceA ::
+     SomeRecord (K Int)
+  -> Fun (Int, Word) (Int, Word)
+  -> Property
+test_sequenceA r (applyFun -> f) =
+        (run $ onModlRecordM Modl.sequenceA r')
+    === (run $ onAnonRecordM Anon.sequenceA r')
+  where
+    run :: State Word a -> a
+    run = flip evalState 0
+
+    r' :: SomeRecord (State Word :.: K Int)
+    r' = onModlRecord (Modl.map f') r
+
+    f' :: K Int x -> (State Word :.: K Int) x
+    f' (K x) = Comp $ state $ \s -> first K $ f (x, s)
+
+test_pure :: SomeFields -> Property
+test_pure sf =
+        someModlRecord sf (\mf -> Modl.pure mf (K True))
+    === someAnonRecord sf (       Anon.pure    (K True))
+
+test_ap ::
+     SomeRecordPair (K Int) (K Int)
+  -> Property
+test_ap (SR2 mf rx ry) =
+        onModlRecordPair Modl.ap r'
+    === onAnonRecordPair Anon.ap r'
+  where
+    r' :: SomeRecordPair (K Int -.-> K Int) (K Int)
+    r' = SR2 mf (Modl.map f rx) ry
+
+    f :: K Int x -> (K Int -.-> K Int) x
+    f (K x) = fn $ \(K y) -> K (x + y)

--- a/large-anon/test/Test/Record/Anonymous/Prop/Model.hs
+++ b/large-anon/test/Test/Record/Anonymous/Prop/Model.hs
@@ -1,0 +1,163 @@
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE ExplicitNamespaces  #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE KindSignatures      #-}
+{-# LANGUAGE OverloadedLabels    #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies        #-}
+{-# LANGUAGE TypeOperators       #-}
+
+{-# OPTIONS_GHC -fplugin=Data.Record.Anonymous.Plugin #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- | Model for records
+--
+-- 'NP' from @sop-core@ forms the basis for our model, along with a choice of
+-- shape (zero, one, or two fields).
+--
+-- Intended for qualified import.
+--
+-- > import Test.Record.Anonymous.Prop.Model (ModelRecord(..), ModelFields(..))
+-- > import qualified Test.Record.Anonymous.Prop.Model as Model
+module Test.Record.Anonymous.Prop.Model (
+    -- * Model proper
+    ModelFields(..)
+  , Types
+  , ModelRecord(..)
+    -- * Conversion to/from 'Record'
+  , toRecord
+  , fromRecord
+    -- * Combinators
+    -- ** "Functor"
+  , map
+  , mapM
+    -- ** Zipping
+  , zip
+  , zipWith
+  , zipWithM
+    -- ** "Foldable"
+  , collapse
+    -- ** "Traversable"
+  , sequenceA
+    -- ** "Applicative"
+  , pure
+  , ap
+  ) where
+
+import Prelude hiding (map, mapM, zip, zipWith, sequenceA, pure)
+
+import Data.Functor.Product
+import Data.Kind
+import Data.SOP (NP(..), type (-.->)(..), SListI)
+import Data.SOP.BasicFunctors
+import GHC.TypeLits
+
+import qualified Data.SOP as SOP
+
+import Data.Record.Anonymous (Record)
+import qualified Data.Record.Anonymous as Anon
+
+{-------------------------------------------------------------------------------
+  Model proper
+-------------------------------------------------------------------------------}
+
+data ModelFields :: [(Symbol, Type)] -> Type where
+  MF0 :: ModelFields '[                           ]
+  MF1 :: ModelFields '[              '("b", Bool) ]
+  MF2 :: ModelFields '[ '("a", Int), '("b", Bool) ]
+
+deriving instance Show (ModelFields xs)
+deriving instance Eq   (ModelFields xs)
+
+type family Types (fields :: [(Symbol, Type)]) :: [Type] where
+  Types '[]             = '[]
+  Types ('(_, t) ': ts) = t ': Types ts
+
+data ModelRecord f r = MR (NP f (Types r))
+
+deriving instance Show (NP f (Types r)) => Show (ModelRecord f r)
+deriving instance Eq   (NP f (Types r)) => Eq   (ModelRecord f r)
+
+{-------------------------------------------------------------------------------
+  Conversion from/to model
+-------------------------------------------------------------------------------}
+
+toRecord :: ModelFields xs -> ModelRecord f xs -> Record f xs
+toRecord MF0 (MR Nil) =
+      Anon.empty
+toRecord MF1 (MR (b :* Nil)) =
+      Anon.insert #b b
+    $ Anon.empty
+toRecord MF2 (MR (a :* b :* Nil)) =
+      Anon.insert #a a
+    $ Anon.insert #b b
+    $ Anon.empty
+
+fromRecord :: ModelFields xs -> Record f xs -> ModelRecord f xs
+fromRecord MF0 _r =
+    MR Nil
+fromRecord MF1 r =
+    MR (Anon.get #b r :* Nil)
+fromRecord MF2 r =
+    MR (Anon.get #a r :* Anon.get #b r :* Nil)
+
+{-------------------------------------------------------------------------------
+  Simple combinators
+-------------------------------------------------------------------------------}
+
+map ::
+     SListI (Types r)
+  => (forall x. f x -> g x) -> ModelRecord f r -> ModelRecord g r
+map f (MR np) = MR (SOP.hmap f np)
+
+mapM ::
+     SListI (Types r)
+  => Applicative m
+  => (forall x. f x -> m (g x))
+  -> ModelRecord f r -> m (ModelRecord g r)
+mapM f (MR np) = MR <$> SOP.htraverse' f np
+
+zip ::
+     SListI (Types r)
+  => ModelRecord f r -> ModelRecord g r -> ModelRecord (Product f g) r
+zip = zipWith Pair
+
+zipWith ::
+     SListI (Types r)
+  => (forall x. f x -> g x -> h x)
+  -> ModelRecord f r -> ModelRecord g r -> ModelRecord h r
+zipWith f (MR np) (MR np') = MR (SOP.hzipWith f np np')
+
+zipWithM :: forall m f g h r.
+     SListI (Types r)
+  => Applicative m
+  => (forall x. f x -> g x -> m (h x))
+  -> ModelRecord f r -> ModelRecord g r -> m (ModelRecord h r)
+zipWithM f (MR np) (MR np') =
+    fmap MR $ SOP.hsequence' $ SOP.hzipWith f' np np'
+  where
+    f' :: forall x. f x -> g x -> (m :.: h) x
+    f' x y = Comp $ f x y
+
+collapse :: SListI (Types r) => ModelRecord (K a) r -> [a]
+collapse (MR np) = SOP.hcollapse np
+
+sequenceA ::
+     SListI (Types r)
+  => Applicative m
+  => ModelRecord (m :.: f) r -> m (ModelRecord f r)
+sequenceA (MR np) = MR <$> SOP.hsequence' np
+
+pure :: ModelFields r -> (forall x. f x) -> ModelRecord f r
+pure MF0 _ = MR Nil
+pure MF1 f = MR (f :* Nil)
+pure MF2 f = MR (f :* f :* Nil)
+
+ap ::
+     SListI (Types r)
+  => ModelRecord (f -.-> g) r -> ModelRecord f r -> ModelRecord g r
+ap (MR np) (MR np') = MR $ SOP.hliftA2 apFn np np'
+

--- a/large-anon/test/Test/Record/Anonymous/Prop/Model/Generator.hs
+++ b/large-anon/test/Test/Record/Anonymous/Prop/Model/Generator.hs
@@ -1,0 +1,294 @@
+{-# LANGUAGE DataKinds            #-}
+{-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE FlexibleInstances    #-}
+{-# LANGUAGE GADTs                #-}
+{-# LANGUAGE KindSignatures       #-}
+{-# LANGUAGE PolyKinds            #-}
+{-# LANGUAGE RankNTypes           #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE StandaloneDeriving   #-}
+{-# LANGUAGE TypeFamilies         #-}
+{-# LANGUAGE TypeOperators        #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+{-# OPTIONS_GHC -fplugin=Data.Record.Anonymous.Plugin #-}
+{-# OPTIONS -Wno-orphans #-}
+
+module Test.Record.Anonymous.Prop.Model.Generator (
+    -- * Existential wrapper around 'ModelRecord' that hides the record shape
+    SomeFields(..)
+  , SomeRecord(..)
+  , SomeRecordPair(..)
+    -- * Construction
+  , someModlRecord
+  , someAnonRecord
+    -- * Mapping
+  , onModlRecord
+  , onModlRecordM
+  , onModlRecordPair
+  , onModlRecordPairM
+  , onAnonRecord
+  , onAnonRecordM
+  , onAnonRecordPair
+  , onAnonRecordPairM
+  ) where
+
+import Data.SOP (NP(..), SListI)
+import Data.SOP.BasicFunctors
+
+import Data.Record.Anonymous (Record, RecordMetadata)
+
+import Test.QuickCheck
+
+import Test.Record.Anonymous.Prop.Model (ModelRecord(..), ModelFields(..), Types)
+
+import qualified Test.Record.Anonymous.Prop.Model as Model
+
+{-------------------------------------------------------------------------------
+  Existential wrapper around 'ModelRecord' that hides the record shape
+-------------------------------------------------------------------------------}
+
+data SomeFields where
+  SF :: SListI (Types r) => ModelFields r -> SomeFields
+
+data SomeRecord f where
+  SR :: SListI (Types r)
+     => ModelFields r -> ModelRecord f r -> SomeRecord f
+
+data SomeRecordPair f g where
+  SR2 :: SListI (Types r)
+      => ModelFields r
+      -> ModelRecord f r -> ModelRecord g r -> SomeRecordPair f g
+
+{-------------------------------------------------------------------------------
+  Construction
+-------------------------------------------------------------------------------}
+
+someModlRecord ::
+     SomeFields
+  -> ( forall r.
+            SListI (Types r)
+         => ModelFields r -> ModelRecord f r
+     )
+  -> SomeRecord f
+someModlRecord (SF mf) f = SR mf (f mf)
+
+someAnonRecord :: forall f.
+     SomeFields
+  -> ( forall r.
+            RecordMetadata f r
+         => Record f r
+     )
+  -> SomeRecord f
+someAnonRecord (SF mf) f = SR mf (Model.fromRecord mf $ f' mf)
+  where
+    f' :: ModelFields r -> Record f r
+    f' MF0 = f
+    f' MF1 = f
+    f' MF2 = f
+
+{-------------------------------------------------------------------------------
+  Mapping
+-------------------------------------------------------------------------------}
+
+onModlRecord :: forall f g.
+     ( forall r.
+            SListI (Types r)
+         => ModelRecord f r -> ModelRecord g r
+     )
+  -> SomeRecord f -> SomeRecord g
+onModlRecord f = unI . onModlRecordM (I . f)
+
+onModlRecordM ::
+     Functor m
+  => ( forall r.
+            SListI (Types r)
+         => ModelRecord f r -> m (ModelRecord g r)
+     )
+  -> SomeRecord f -> m (SomeRecord g)
+onModlRecordM f (SR mf r) = SR mf <$> f r
+
+onModlRecordPair ::
+     ( forall r.
+            SListI (Types r)
+         => ModelRecord f r -> ModelRecord g r -> ModelRecord h r
+     )
+  -> SomeRecordPair f g -> SomeRecord h
+onModlRecordPair f = unI . onModlRecordPairM (I .: f)
+
+onModlRecordPairM ::
+     Functor m
+  => ( forall r.
+            SListI (Types r)
+         => ModelRecord f r -> ModelRecord g r -> m (ModelRecord h r)
+     )
+  -> SomeRecordPair f g -> m (SomeRecord h)
+onModlRecordPairM f (SR2 mf r r') = SR mf <$> f r r'
+
+onAnonRecord :: forall f g.
+     (forall r. Record f r -> Record g r)
+  -> SomeRecord f -> SomeRecord g
+onAnonRecord f = unI . onAnonRecordM (I . f)
+
+onAnonRecordM :: forall m f g.
+     Functor m
+  => (forall r. Record f r -> m (Record g r))
+  -> SomeRecord f -> m (SomeRecord g)
+onAnonRecordM f = \(SR mf r) -> SR mf <$> f' mf r
+  where
+    f' :: forall r. ModelFields r -> ModelRecord f r -> m (ModelRecord g r)
+    f' mf r =
+        Model.fromRecord mf <$>
+          f (Model.toRecord mf r)
+
+onAnonRecordPair :: forall f g h.
+     (forall r. Record f r -> Record g r -> Record h r)
+  -> SomeRecordPair f g -> SomeRecord h
+onAnonRecordPair f = unI . onAnonRecordPairM (I .: f)
+
+onAnonRecordPairM :: forall m f g h.
+     Functor m
+  => (forall r. Record f r -> Record g r -> m (Record h r))
+  -> SomeRecordPair f g -> m (SomeRecord h)
+onAnonRecordPairM f = \(SR2 mf r r') -> SR mf <$> f' mf r r'
+  where
+    f' :: forall r.
+         ModelFields r
+      -> ModelRecord f r -> ModelRecord g r -> m (ModelRecord h r)
+    f' mf r r' =
+        Model.fromRecord mf <$>
+          f (Model.toRecord mf r) (Model.toRecord mf r')
+
+{-------------------------------------------------------------------------------
+  Generators for ModelRecord for concrete rows
+-------------------------------------------------------------------------------}
+
+instance Arbitrary (ModelRecord f '[]) where
+  arbitrary = pure $ MR Nil
+
+instance ( Arbitrary (f Bool)
+         ) => Arbitrary (ModelRecord f '[ '("b", Bool) ]) where
+  arbitrary =
+          (\x -> MR (x :* Nil))
+      <$> arbitrary
+
+  shrink (MR (x :* Nil)) = concat [
+        (\x' -> MR (x' :* Nil)) <$> shrink x
+      ]
+
+instance ( Arbitrary (f Int)
+         , Arbitrary (f Bool)
+         ) => Arbitrary (ModelRecord f '[ '("a", Int), '("b", Bool) ]) where
+  arbitrary =
+          (\x y -> MR (x :* y :* Nil))
+      <$> arbitrary
+      <*> arbitrary
+
+  shrink (MR (x :* y :* Nil)) = concat [
+        (\x' -> MR (x' :* y  :* Nil)) <$> shrink x
+      , (\y' -> MR (x  :* y' :* Nil)) <$> shrink y
+      ]
+
+{-------------------------------------------------------------------------------
+  Generators for existential wrappers
+-------------------------------------------------------------------------------}
+
+instance Arbitrary SomeFields where
+  arbitrary = elements [
+        SF MF0
+      , SF MF1
+      , SF MF2
+      ]
+
+  shrink (SF MF0) = []
+  shrink (SF MF1) = [SF MF0]
+  shrink (SF MF2) = [SF MF1]
+
+instance ( Arbitrary (f Int), Arbitrary (f Bool)
+         ) => Arbitrary (SomeRecord f) where
+  arbitrary = oneof [
+        SR MF0 <$> arbitrary
+      , SR MF1 <$> arbitrary
+      , SR MF2 <$> arbitrary
+      ]
+
+  shrink (SR MF0 r) = concat [
+        SR MF0 <$> shrink r
+      ]
+  shrink (SR MF1 r) = concat [
+        SR MF1 <$> shrink r
+      , pure $ SR MF0 (dropHead r)
+      ]
+  shrink (SR MF2 r) = concat [
+        SR MF2 <$> shrink r
+      , pure $ SR MF1 (dropHead r)
+      ]
+
+instance ( Arbitrary (f Int), Arbitrary (f Bool)
+         , Arbitrary (g Int), Arbitrary (g Bool)
+         ) => Arbitrary (SomeRecordPair f g) where
+  arbitrary = oneof [
+        SR2 MF0 <$> arbitrary <*> arbitrary
+      , SR2 MF1 <$> arbitrary <*> arbitrary
+      , SR2 MF2 <$> arbitrary <*> arbitrary
+      ]
+
+  shrink (SR2 MF0 r r') = concat [
+        SR2 MF0 <$> shrink r <*> pure   r'
+      , SR2 MF0 <$> pure   r <*> shrink r'
+      ]
+  shrink (SR2 MF1 r r') = concat [
+        SR2 MF1 <$> shrink r <*> pure   r'
+      , SR2 MF1 <$> pure   r <*> shrink r'
+      , pure $ SR2 MF0 (dropHead r) (dropHead r')
+      ]
+  shrink (SR2 MF2 r r') = concat [
+        SR2 MF2 <$> shrink r <*> pure   r'
+      , SR2 MF2 <$> pure   r <*> shrink r'
+      , pure $ SR2 MF1 (dropHead r) (dropHead r')
+      ]
+
+{-------------------------------------------------------------------------------
+  Show/Eq instances
+-------------------------------------------------------------------------------}
+
+deriving instance Show SomeFields
+
+instance ( Show (f Int), Show (f Bool)
+         ) => Show (SomeRecord f) where
+  show (SR MF0 r) = show r
+  show (SR MF1 r) = show r
+  show (SR MF2 r) = show r
+
+instance ( Show (f Int), Show (f Bool)
+         , Show (g Int), Show (g Bool)
+         ) => Show (SomeRecordPair f g) where
+  show (SR2 MF0 r r') = show (r, r')
+  show (SR2 MF1 r r') = show (r, r')
+  show (SR2 MF2 r r') = show (r, r')
+
+instance ( Eq (f Int), Eq (f Bool)
+         ) => Eq (SomeRecord f) where
+  SR MF0 r == SR MF0 r' = r == r'
+  SR MF1 r == SR MF1 r' = r == r'
+  SR MF2 r == SR MF2 r' = r == r'
+  _        == _         = False
+
+instance ( Eq (f Int), Eq (f Bool)
+         , Eq (g Int), Eq (g Bool)
+         ) => Eq (SomeRecordPair f g) where
+  SR2 MF0 r1 r2 == SR2 MF0 r1' r2' = r1 == r1' && r2 == r2'
+  SR2 MF1 r1 r2 == SR2 MF1 r1' r2' = r1 == r1' && r2 == r2'
+  SR2 MF2 r1 r2 == SR2 MF2 r1' r2' = r1 == r1' && r2 == r2'
+  _             == _               = False
+
+{-------------------------------------------------------------------------------
+  Auxiliary
+-------------------------------------------------------------------------------}
+
+dropHead :: ModelRecord f ('(fld, x) ': xs) -> ModelRecord f xs
+dropHead (MR (_ :* xs)) = MR xs
+
+(.:) :: (c -> d) -> (a -> b -> c) -> a -> b -> d
+(f .: g) x y = f (g x y)
+

--- a/large-anon/test/Test/Record/Anonymous/Prop/Model/Orphans.hs
+++ b/large-anon/test/Test/Record/Anonymous/Prop/Model/Orphans.hs
@@ -1,0 +1,11 @@
+{-# OPTIONS -Wno-orphans #-}
+
+module Test.Record.Anonymous.Prop.Model.Orphans () where
+
+import Data.SOP.BasicFunctors
+
+import Test.QuickCheck
+
+instance Arbitrary a => Arbitrary (K a b) where
+  arbitrary    = K <$> arbitrary
+  shrink (K a) = K <$> shrink a

--- a/large-anon/test/TestLargeAnon.hs
+++ b/large-anon/test/TestLargeAnon.hs
@@ -7,12 +7,18 @@ import qualified Test.Record.Anonymous.Sanity.Merging
 import qualified Test.Record.Anonymous.Sanity.Casting
 import qualified Test.Record.Anonymous.Sanity.DuplicateFields
 import qualified Test.Record.Anonymous.Sanity.TypeLevelMetadata
+import qualified Test.Record.Anonymous.Prop.Combinators.Simple
 
 main :: IO ()
 main = defaultMain $ testGroup "large-anon" [
-      Test.Record.Anonymous.Sanity.Basics.tests
-    , Test.Record.Anonymous.Sanity.Merging.tests
-    , Test.Record.Anonymous.Sanity.Casting.tests
-    , Test.Record.Anonymous.Sanity.DuplicateFields.tests
-    , Test.Record.Anonymous.Sanity.TypeLevelMetadata.tests
+      testGroup "Sanity" [
+          Test.Record.Anonymous.Sanity.Basics.tests
+        , Test.Record.Anonymous.Sanity.Merging.tests
+        , Test.Record.Anonymous.Sanity.Casting.tests
+        , Test.Record.Anonymous.Sanity.DuplicateFields.tests
+        , Test.Record.Anonymous.Sanity.TypeLevelMetadata.tests
+        ]
+    , testGroup "Prop" [
+          Test.Record.Anonymous.Prop.Combinators.Simple.tests
+        ]
     ]


### PR DESCRIPTION
These are all the non-constrained combinators that we also provide for `Rep` (in `large-generics`). The constrained versions need a change to how we deal with constraints, but that in turn requires these simple combinators first, so this is step 1.

This also provides infrastructure for doing property tests over records.