### PR TITLE
Delete `canonIndices` from `Canonical`

### DIFF
--- a/large-anon/src/Data/Record/Anonymous/Internal/Diff.hs
+++ b/large-anon/src/Data/Record/Anonymous/Internal/Diff.hs
@@ -90,15 +90,13 @@ empty = Diff {
 -- > Diff.get f d c == Canon.get f (Diff.apply d c)
 --
 -- @O(1)@.
-get :: String -> Diff f -> Canonical f -> f Any
-get f Diff{..} c =
+get :: (Int, String) -> Diff f -> Canonical f -> f Any
+get (i, f) Diff{..} c =
     case HashMap.lookup f diffNew of
       Just x  -> x                                   -- inserted  in the diff
-      Nothing -> case HashMap.lookup ix diffUpd of
+      Nothing -> case HashMap.lookup i diffUpd of
                    Just x  -> x                      -- updated   in the diff
-                   Nothing -> Canon.getAtIndex c ix  -- unchanged in the diff
-        where
-          ix = Canon.indexOf c f
+                   Nothing -> Canon.getAtIndex c i   -- unchanged in the diff
 
 -- | Update existing field
 --
@@ -121,13 +119,11 @@ get f Diff{..} c =
 --   but only the first value will matter as it will shadow all the others.
 --
 -- @O(1)@.
-set :: String -> f Any -> Canonical f -> Diff f -> Diff f
-set f x c d@Diff{..} =
+set :: (Int, String) -> f Any -> Diff f -> Diff f
+set (i, f) x d@Diff{..} =
     case tryUpdateHashMap f (const x) diffNew of
       Just diffNew' -> d { diffNew = diffNew' }
-      Nothing       -> d { diffUpd = HashMap.insert ix x diffUpd }
-        where
-          ix = Canon.indexOf c f
+      Nothing       -> d { diffUpd = HashMap.insert i x diffUpd }
 
 -- | Insert new field
 --
@@ -180,7 +176,7 @@ fromCanonical :: Canonical f -> Diff f
 fromCanonical c = Diff {
       diffUpd = HashMap.empty
     , diffNew = HashMap.fromList (Canon.toList c)
-    , diffIns = map fst (canonFields c)
+    , diffIns = canonFields c
     }
 
 {-------------------------------------------------------------------------------

--- a/large-anon/src/Data/Record/Anonymous/Internal/Record.hs
+++ b/large-anon/src/Data/Record/Anonymous/Internal/Record.hs
@@ -246,12 +246,7 @@ merge (canonicalize -> r) (canonicalize -> r') =
 -- ...
 -- ...No instance for (Isomorphic...
 -- ...
-castRecord :: forall f r r'.
-     (Isomorphic r r', KnownFields r')
-  => Record f r -> Record f r'
+castRecord :: forall f r r'. Isomorphic r r' => Record f r -> Record f r'
 castRecord (canonicalize -> r) =
-    unsafeFromCanonical $ Canon.reshuffle newOrder r
-  where
-    newOrder :: [String]
-    newOrder = fieldNames (Proxy @r')
-
+    unsafeFromCanonical $
+      Canon.reshuffle (isomorphic (Proxy @r) (Proxy @r')) r

--- a/large-anon/src/Data/Record/Anonymous/Internal/Row.hs
+++ b/large-anon/src/Data/Record/Anonymous/Internal/Row.hs
@@ -14,7 +14,9 @@
 -- Intended for unqualified import.
 module Data.Record.Anonymous.Internal.Row (
     -- * Isomorphic records
-    Isomorphic
+    Isomorphic(..)
+  , IsomorphicDict
+  , Permutation(..)
     -- * Merging records
   , Merge
     -- * Constraints
@@ -44,7 +46,18 @@ import GHC.TypeLits
 -- Instances of this class are provided by the plugin.
 --
 -- See 'castRecord' for details.
-class Isomorphic (xs :: [(Symbol, Type)]) (ys :: [(Symbol, Type)]) where
+class Isomorphic (r :: [(Symbol, Type)]) (r' :: [(Symbol, Type)]) where
+  isomorphic :: IsomorphicDict r r'
+
+type IsomorphicDict (r :: [(Symbol, Type)]) (r' :: [(Symbol, Type)]) =
+       Proxy r -> Proxy r' -> Permutation
+
+-- | Evidence that two records as isomorphic
+--
+-- This is an internal type that is not exposed to the user.
+newtype Permutation =
+   -- | In order of the fields in the /target/ record, the index in the /source/
+   Permutation [(String, Int)]
 
 {-------------------------------------------------------------------------------
   Merging records

--- a/large-anon/src/Data/Record/Anonymous/Plugin/NameResolution.hs
+++ b/large-anon/src/Data/Record/Anonymous/Plugin/NameResolution.hs
@@ -21,8 +21,9 @@ data ResolvedNames = ResolvedNames {
     , dataConFieldLazy       :: DataCon
     , dataConFieldMetadata   :: DataCon
     , dataConProxy           :: DataCon
-    , idEvidenceHasField     :: Id
     , idEvidenceAllFields    :: Id
+    , idEvidenceHasField     :: Id
+    , idEvidenceIsomorphic   :: Id
     , idEvidenceKnownFields  :: Id
     , idUnsafeCoerce         :: Id
     , tyConDict              :: TyCon
@@ -55,8 +56,9 @@ nameResolution = do
     dataConFieldMetadata <- getDataCon drGeneric "FieldMetadata"
     dataConProxy         <- getDataCon dProxy    "Proxy"
 
-    idEvidenceHasField    <- getVar draiEvidence "evidenceHasField"
     idEvidenceAllFields   <- getVar draiEvidence "evidenceAllFields"
+    idEvidenceHasField    <- getVar draiEvidence "evidenceHasField"
+    idEvidenceIsomorphic  <- getVar draiEvidence "evidenceIsomorphic"
     idEvidenceKnownFields <- getVar draiEvidence "evidenceKnownFields"
     idUnsafeCoerce        <- getVar uCoerce      "unsafeCoerce"
 

--- a/large-anon/src/Data/Record/Anonymous/Simple.hs
+++ b/large-anon/src/Data/Record/Anonymous/Simple.hs
@@ -98,7 +98,7 @@ insert nm x = fromAdvanced . Adv.insert nm (I x) . toAdvanced
 merge :: Record r -> Record r' -> Record (Merge r r')
 merge r r' = fromAdvanced $ Adv.merge (toAdvanced r) (toAdvanced r')
 
-castRecord :: (Isomorphic r r', KnownFields r') => Record r -> Record r'
+castRecord :: Isomorphic r r' => Record r -> Record r'
 castRecord = fromAdvanced . Adv.castRecord . toAdvanced
 
 {-------------------------------------------------------------------------------


### PR DESCRIPTION
Instead we compute all indices at runtime. We only _use_ them if we have no `Diff`, but there is no need to do a `HashMap` lookup anymore on the field names. This means that field lookup will be `O(1)` in the typical case, and `O(log n)` in the worst case (if we have a `Diff`).