### PR TITLE
Define intersection in user-land

### DIFF
--- a/large-anon/large-anon.cabal
+++ b/large-anon/large-anon.cabal
@@ -65,10 +65,10 @@ library
       Data.Record.Anonymous.SrcPlugin.Options
 
       Data.Record.Anonymous.TcPlugin.Constraints.AllFields
-      Data.Record.Anonymous.TcPlugin.Constraints.HasField
       Data.Record.Anonymous.TcPlugin.Constraints.KnownFields
       Data.Record.Anonymous.TcPlugin.Constraints.KnownHash
       Data.Record.Anonymous.TcPlugin.Constraints.Project
+      Data.Record.Anonymous.TcPlugin.Constraints.RowHasField
       Data.Record.Anonymous.TcPlugin.GhcTcPluginAPI
       Data.Record.Anonymous.TcPlugin.NameResolution
       Data.Record.Anonymous.TcPlugin.Parsing
@@ -91,7 +91,6 @@ library
     , record-hasfield
     , sop-core
     , syb
-    , text
     , typelet
     , vector
 
@@ -109,6 +108,9 @@ library
       -Wredundant-constraints
       -Wno-unticked-promoted-constructors
 
+  if impl(ghc >= 8.10)
+    ghc-options: -Wunused-packages
+
 test-suite test-large-anon
   default-language:
       Haskell2010
@@ -121,6 +123,7 @@ test-suite test-large-anon
   other-modules:
       Test.Infra.Generics
       Test.Infra.MarkStrictness
+      Test.Infra.Discovery
       Test.Infra.DynRecord
       Test.Infra.DynRecord.Advanced
       Test.Infra.DynRecord.Simple
@@ -131,10 +134,12 @@ test-suite test-large-anon
       Test.Prop.Record.Model.Orphans
       Test.Sanity.AllFields
       Test.Sanity.Applicative
+      Test.Sanity.CheckCanProject
       Test.Sanity.Discovery
       Test.Sanity.DuplicateFields
       Test.Sanity.Generics
       Test.Sanity.HasField
+      Test.Sanity.Intersection
       Test.Sanity.Lens
       Test.Sanity.Merging
       Test.Sanity.Named.Record1
@@ -150,20 +155,24 @@ test-suite test-large-anon
       base
     , aeson
     , large-anon
+    , large-generics
     , mtl
     , QuickCheck
+    , record-hasfield
     , sop-core
     , tasty
     , tasty-hunit
     , tasty-quickcheck
     , typelet
     , validation-selective
-    , large-generics
-    , record-hasfield
   ghc-options:
       -Wall
+      -Wredundant-constraints
       -Wno-unticked-promoted-constructors
       -fno-show-valid-hole-fits
+
+  if impl(ghc >= 8.10)
+    ghc-options: -Wunused-packages
 
   if impl(ghc >= 9.0.1)
     -- Work out ghc problem. See more detailed discussion in large-records.

--- a/large-anon/src/Data/Record/Anon.hs
+++ b/large-anon/src/Data/Record/Anon.hs
@@ -26,7 +26,7 @@ module Data.Record.Anon (
   , AllFields
   , KnownFields
   , Project
-  , RecordHasField
+  , RowHasField
 
     -- * Fields
   , Field

--- a/large-anon/src/Data/Record/Anon/Simple.hs
+++ b/large-anon/src/Data/Record/Anon/Simple.hs
@@ -27,6 +27,7 @@ module Data.Record.Anon.Simple (
     -- * Changing rows
   , merge
   , project
+  , inject
   , lens
     -- * Interop with the advanced API
   , toAdvanced
@@ -206,14 +207,20 @@ merge = S.merge
 --
 -- As we saw in 'merge', 'project' can also flatten 'Merge'd rows.
 -- See 'Data.Record.Anon.Advanced.project' for additional discussion.
-project :: Project I r r' => Record r -> Record r'
+project :: Project r r' => Record r -> Record r'
 project = S.project
+
+-- | Inject smaller record into larger record
+--
+-- This is just the 'lens' setter.
+inject :: Project r r' => Record r' -> Record r -> Record r
+inject = S.inject
 
 -- | Lens from one record to another
 --
 -- See 'project' for examples ('project' is just the lens getter, without the
 -- setter).
-lens :: Project I r r' => Record r -> (Record r', Record r' -> Record r)
+lens :: Project r r' => Record r -> (Record r', Record r' -> Record r)
 lens = S.lens
 
 {-------------------------------------------------------------------------------

--- a/large-anon/src/Data/Record/Anonymous/Advanced.hs
+++ b/large-anon/src/Data/Record/Anonymous/Advanced.hs
@@ -26,6 +26,7 @@ module Data.Record.Anonymous.Advanced (
   , Record.merge
   , Record.lens
   , Record.project
+  , Record.inject
   , Record.applyPending
     -- * Constraints
   , RecordConstraints
@@ -61,9 +62,6 @@ module Data.Record.Anonymous.Advanced (
   , FieldTypes
   , AllFields
   , KnownFields
-    -- * Additional generic functions
-  , recordOfMetadata
-  , reifyKnownFields
     -- * Support for @typelet@
   , Record.letRecordT
   , Record.letInsertAs
@@ -73,7 +71,7 @@ import Data.Record.Anon.Plugin.Internal.Runtime
 
 import Data.Record.Anonymous.Internal.Record (Record)
 import Data.Record.Anonymous.Internal.Constraints
-import Data.Record.Anonymous.Internal.Generics
+import Data.Record.Anonymous.Internal.Generics ()
 
 import qualified Data.Record.Anonymous.Internal.Combinators.Constrained as Combinators
 import qualified Data.Record.Anonymous.Internal.Combinators.Simple      as Combinators

--- a/large-anon/src/Data/Record/Anonymous/Internal/Constraints.hs
+++ b/large-anon/src/Data/Record/Anonymous/Internal/Constraints.hs
@@ -26,12 +26,11 @@ module Data.Record.Anonymous.Internal.Constraints (
 
 import Data.Kind
 import Data.Proxy
-import Data.SOP.BasicFunctors
 import Data.SOP.Constraint
 import Data.SOP.Dict
 import GHC.Exts (Any)
 
-import Data.Vector.Generic as V
+import qualified Data.Vector.Generic as V
 
 import Data.Record.Anon.Plugin.Internal.Runtime
 
@@ -65,13 +64,12 @@ constrain p (Record.toCanonical -> r) = Record.unsafeFromCanonical $
 class    (AllFields r (Compose c f), KnownFields r) => RecordConstraints f r c
 instance (AllFields r (Compose c f), KnownFields r) => RecordConstraints f r c
 
-reifyAllFields :: forall k l (f :: k -> l) (r :: Row k) (c :: l -> Constraint) proxy.
-     AllFields r (Compose c f)
-  => proxy c -> Record (Dict c :.: f) r
+reifyAllFields :: forall k (r :: Row k) (c :: k -> Constraint) proxy.
+     AllFields r c
+  => proxy c -> Record (Dict c) r
 reifyAllFields _ = Record.unsafeFromCanonical $
     Canon.fromLazyVector $
-      V.map aux $ fieldDicts (Proxy @r) (Proxy @(Compose c f))
+      V.map aux $ fieldDicts (Proxy @r) (Proxy @c)
   where
-    aux :: DictAny (Compose c f) -> (:.:) (Dict c) f Any
-    aux DictAny = Comp Dict
-
+    aux :: DictAny c -> Dict c Any
+    aux DictAny = Dict

--- a/large-anon/src/Data/Record/Anonymous/Internal/Generics.hs
+++ b/large-anon/src/Data/Record/Anonymous/Internal/Generics.hs
@@ -12,11 +12,7 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 -- | Integration with @large-generics@
-module Data.Record.Anonymous.Internal.Generics (
-    -- * Additional generic functions
-    recordOfMetadata
-  , reifyKnownFields
-  ) where
+module Data.Record.Anonymous.Internal.Generics () where
 
 import Data.Aeson (ToJSON(..), FromJSON(..))
 import Data.Kind
@@ -35,7 +31,6 @@ import Data.Record.Anonymous.Internal.Record (Record)
 import Data.Record.Anonymous.Internal.Constraints
 
 import qualified Data.Record.Anonymous.Internal.Rep as Rep
-import qualified Data.Record.Anonymous.Internal.Combinators.Simple as Simple
 
 {-------------------------------------------------------------------------------
   Integrate with large-generics
@@ -98,31 +93,3 @@ instance RecordConstraints f r ToJSON => ToJSON (Record f r) where
 
 instance RecordConstraints f r FromJSON => FromJSON (Record f r) where
   parseJSON = gparseJSON
-
-{-------------------------------------------------------------------------------
-  Additional functions
--------------------------------------------------------------------------------}
-
--- | Construct record with field metadata for every field
-recordOfMetadata :: forall k (f :: k -> Type) (r :: Row k) proxy.
-     KnownFields r
-  => proxy r -> Record (FieldMetadata :.: f) r
-recordOfMetadata _ =
-    Rep.toRecord' md
-  where
-    md :: Rep FieldMetadata (Record f r)
-    md = recordFieldMetadata (metadata (Proxy @(Record f r)))
-
--- | Like 'recordOfMetadata', but includes field names only
-reifyKnownFields :: forall k (r :: Row k) proxy.
-     KnownFields r
-  => proxy r -> Record (K String) r
-reifyKnownFields _ =
-    Simple.map aux $ Rep.toRecord' md
-  where
-    md :: Rep (K String) (Record (K ()) r)
-    md = recordFieldNames (metadata (Proxy @(Record (K ()) r)))
-
-    aux :: (K String :.: f) x -> K String x
-    aux (Comp (K name)) = K name
-

--- a/large-anon/src/Data/Record/Anonymous/Internal/Reflection.hs
+++ b/large-anon/src/Data/Record/Anonymous/Internal/Reflection.hs
@@ -18,6 +18,7 @@ module Data.Record.Anonymous.Internal.Reflection (
   , unsafeReflectKnownFields
   , unsafeReflectAllFields
   , unsafeReflectProject
+  , unsafeReflectRowHasField
   ) where
 
 import Data.Record.Anon.Plugin.Internal.Runtime
@@ -42,7 +43,12 @@ newtype WithAllFields r c = WAF (AllFields r c => Reflected (AllFields r c))
 unsafeReflectAllFields :: DictAllFields k r c -> Reflected (AllFields r c)
 unsafeReflectAllFields f = noInlineUnsafeCo (WAF Reflected) f
 
-newtype WithProject f r r' = WR (Project f r r' => Reflected (Project f r r'))
+newtype WithProject r r' = WR (Project r r' => Reflected (Project r r'))
 
-unsafeReflectProject :: DictProject k f r r' -> Reflected (Project f r r')
+unsafeReflectProject :: DictProject k r r' -> Reflected (Project r r')
 unsafeReflectProject = noInlineUnsafeCo (WR Reflected)
+
+newtype WithRowHasField n r a = WRHF (RowHasField n r a => Reflected (RowHasField n r a))
+
+unsafeReflectRowHasField :: DictRowHasField k n r a -> Reflected (RowHasField n r a)
+unsafeReflectRowHasField = noInlineUnsafeCo (WRHF Reflected)

--- a/large-anon/src/Data/Record/Anonymous/Simple.hs
+++ b/large-anon/src/Data/Record/Anonymous/Simple.hs
@@ -49,6 +49,7 @@ module Data.Record.Anonymous.Simple (
   , merge
   , lens
   , project
+  , inject
   , applyPending
     -- * Constraints
   , RecordConstraints
@@ -133,14 +134,17 @@ insertA f x r = insert f <$> x <*> r
 merge :: Record r -> Record r' -> Record (Merge r r')
 merge r r' = fromAdvanced $ Adv.merge (toAdvanced r) (toAdvanced r')
 
-lens :: Project I r r' => Record r -> (Record r', Record r' -> Record r)
+lens :: Project r r' => Record r -> (Record r', Record r' -> Record r)
 lens =
       bimap fromAdvanced (\f -> fromAdvanced . f . toAdvanced)
     . Adv.lens
     . toAdvanced
 
-project :: Project I r r' => Record r -> Record r'
+project :: Project r r' => Record r -> Record r'
 project = fst . lens
+
+inject :: Project r r' => Record r' -> Record r -> Record r
+inject small = ($ small) . snd . lens
 
 applyPending :: Record r -> Record r
 applyPending = fromAdvanced . Adv.applyPending . toAdvanced

--- a/large-anon/src/Data/Record/Anonymous/TcPlugin/Constraints/Project.hs
+++ b/large-anon/src/Data/Record/Anonymous/TcPlugin/Constraints/Project.hs
@@ -25,16 +25,13 @@ import qualified Data.Record.Anonymous.Internal.Row.ParsedRow as ParsedRow
 
 -- | Parsed form of @Project@
 --
--- > Project f (r :: [(Symbol, k)]) (r' :: [(Symbol, k)])
+-- > Project (r :: [(Symbol, k)]) (r' :: [(Symbol, k)])
 data CProject = CProject {
       -- | Fields on the LHS
       projectParsedLHS :: Fields
 
       -- | Fields on the RHS
     , projectParsedRHS :: Fields
-
-      -- | Functor argument (@f@)
-    , projectTypeFunctor :: Type
 
       -- | Left-hand side of the projection (@r@)
     , projectTypeLHS :: Type
@@ -51,11 +48,10 @@ data CProject = CProject {
 -------------------------------------------------------------------------------}
 
 instance Outputable CProject where
-  ppr (CProject parsedLHS parsedRHS typeFunctor typeLHS typeRHS typeKind) = parens $
+  ppr (CProject parsedLHS parsedRHS typeLHS typeRHS typeKind) = parens $
       text "CProject" <+> braces (vcat [
           text "projectParsedLHS"   <+> text "=" <+> ppr parsedLHS
         , text "projectParsedRHS"   <+> text "=" <+> ppr parsedRHS
-        , text "projectTypeFunctor" <+> text "=" <+> ppr typeFunctor
         , text "projectTypeLHS"     <+> text "=" <+> ppr typeLHS
         , text "projectTypeRHS"     <+> text "=" <+> ppr typeRHS
         , text "projectTypeKind"    <+> text "=" <+> ppr typeKind
@@ -71,16 +67,15 @@ parseProject ::
   -> Ct
   -> ParseResult Void (GenLocated CtLoc CProject)
 parseProject tcs rn@ResolvedNames{..} =
-    parseConstraint' clsProject $ \[typeKind, typeFunctor, typeLHS, typeRHS] -> do
+    parseConstraint' clsProject $ \[typeKind, typeLHS, typeRHS] -> do
       fieldsLHS <- ParsedRow.parseFields tcs rn typeLHS
       fieldsRHS <- ParsedRow.parseFields tcs rn typeRHS
       return $ CProject {
-            projectParsedLHS   = fieldsLHS
-          , projectParsedRHS   = fieldsRHS
-          , projectTypeFunctor = typeFunctor
-          , projectTypeLHS     = typeLHS
-          , projectTypeRHS     = typeRHS
-          , projectTypeKind    = typeKind
+            projectParsedLHS = fieldsLHS
+          , projectParsedRHS = fieldsRHS
+          , projectTypeLHS   = typeLHS
+          , projectTypeRHS   = typeRHS
+          , projectTypeKind  = typeKind
           }
 
 {-------------------------------------------------------------------------------
@@ -107,7 +102,6 @@ evidenceProject ResolvedNames{..} CProject{..} fields = do
     typeArgsEvidence :: [Type]
     typeArgsEvidence = [
           projectTypeKind
-        , projectTypeFunctor
         , projectTypeLHS
         , projectTypeRHS
         ]

--- a/large-anon/src/Data/Record/Anonymous/TcPlugin/NameResolution.hs
+++ b/large-anon/src/Data/Record/Anonymous/TcPlugin/NameResolution.hs
@@ -12,23 +12,23 @@ import Data.Record.Anonymous.TcPlugin.GhcTcPluginAPI
 --
 -- Listed alphabetically.
 data ResolvedNames = ResolvedNames {
-      clsAllFields             :: Class
-    , clsKnownFields           :: Class
-    , clsKnownHash             :: Class
-    , clsProject               :: Class
-    , clsRecordHasField        :: Class
-    , dataConDictAny           :: DataCon
-    , idEvidenceAllFields      :: Id
-    , idEvidenceKnownFields    :: Id
-    , idEvidenceKnownHash      :: Id
-    , idEvidenceProject        :: Id
-    , idEvidenceRecordHasField :: Id
-    , idUnsafeCoerce           :: Id
-    , tyConDictAny             :: TyCon
-    , tyConMerge               :: TyCon
-    , tyConFieldTypes          :: TyCon
-    , tyConPair                :: TyCon
-    , tyConSimpleFieldTypes    :: TyCon
+      clsAllFields          :: Class
+    , clsKnownFields        :: Class
+    , clsKnownHash          :: Class
+    , clsProject            :: Class
+    , clsRowHasField        :: Class
+    , dataConDictAny        :: DataCon
+    , idEvidenceAllFields   :: Id
+    , idEvidenceKnownFields :: Id
+    , idEvidenceKnownHash   :: Id
+    , idEvidenceProject     :: Id
+    , idEvidenceRowHasField :: Id
+    , idUnsafeCoerce        :: Id
+    , tyConDictAny          :: TyCon
+    , tyConMerge            :: TyCon
+    , tyConFieldTypes       :: TyCon
+    , tyConPair             :: TyCon
+    , tyConSimpleFieldTypes :: TyCon
     }
 
 nameResolution :: TcPluginM 'Init ResolvedNames
@@ -47,26 +47,26 @@ nameResolution = do
         getVar         var = lookupOrig modl (mkVarOcc var)  >>= tcLookupId
         getPromDataCon con = promoteDataCon <$> getDataCon con
 
-    clsAllFields             <- getClass "AllFields"
-    clsKnownFields           <- getClass "KnownFields"
-    clsKnownHash             <- getClass "KnownHash"
-    clsProject               <- getClass "Project"
-    clsRecordHasField        <- getClass "RecordHasField"
+    clsAllFields          <- getClass "AllFields"
+    clsKnownFields        <- getClass "KnownFields"
+    clsKnownHash          <- getClass "KnownHash"
+    clsProject            <- getClass "Project"
+    clsRowHasField        <- getClass "RowHasField"
 
-    dataConDictAny           <- getDataCon "DictAny"
+    dataConDictAny        <- getDataCon "DictAny"
 
-    idEvidenceAllFields      <- getVar "evidenceAllFields"
-    idEvidenceKnownFields    <- getVar "evidenceKnownFields"
-    idEvidenceKnownHash      <- getVar "evidenceKnownHash"
-    idEvidenceProject        <- getVar "evidenceProject"
-    idEvidenceRecordHasField <- getVar "evidenceRecordHasField"
-    idUnsafeCoerce           <- getVar "noInlineUnsafeCo"
+    idEvidenceAllFields   <- getVar "evidenceAllFields"
+    idEvidenceKnownFields <- getVar "evidenceKnownFields"
+    idEvidenceKnownHash   <- getVar "evidenceKnownHash"
+    idEvidenceProject     <- getVar "evidenceProject"
+    idEvidenceRowHasField <- getVar "evidenceRowHasField"
+    idUnsafeCoerce        <- getVar "noInlineUnsafeCo"
 
-    tyConDictAny             <- getTyCon       "DictAny"
-    tyConFieldTypes          <- getTyCon       "FieldTypes"
-    tyConMerge               <- getTyCon       "Merge"
-    tyConPair                <- getPromDataCon ":="
-    tyConSimpleFieldTypes    <- getTyCon       "SimpleFieldTypes"
+    tyConDictAny          <- getTyCon       "DictAny"
+    tyConFieldTypes       <- getTyCon       "FieldTypes"
+    tyConMerge            <- getTyCon       "Merge"
+    tyConPair             <- getPromDataCon ":="
+    tyConSimpleFieldTypes <- getTyCon       "SimpleFieldTypes"
 
     return $ ResolvedNames {..}
 

--- a/large-anon/src/Data/Record/Anonymous/TcPlugin/Solver.hs
+++ b/large-anon/src/Data/Record/Anonymous/TcPlugin/Solver.hs
@@ -10,10 +10,10 @@ import Data.Maybe (catMaybes)
 import Data.Traversable (forM)
 
 import Data.Record.Anonymous.TcPlugin.Constraints.AllFields
-import Data.Record.Anonymous.TcPlugin.Constraints.HasField
 import Data.Record.Anonymous.TcPlugin.Constraints.KnownFields
 import Data.Record.Anonymous.TcPlugin.Constraints.KnownHash
 import Data.Record.Anonymous.TcPlugin.Constraints.Project
+import Data.Record.Anonymous.TcPlugin.Constraints.RowHasField
 import Data.Record.Anonymous.TcPlugin.GhcTcPluginAPI
 import Data.Record.Anonymous.TcPlugin.NameResolution
 import Data.Record.Anonymous.TcPlugin.Parsing
@@ -29,10 +29,10 @@ solve rn given wanted =
 --  trace _debugParsed $
     do (solved, new) <- fmap (bimap catMaybes concat . unzip) $ concatM [
            forM parsedAllFields   $ uncurry (solveAllFields   rn)
-         , forM parsedHasField    $ uncurry (solveHasField    rn)
          , forM parsedKnownFields $ uncurry (solveKnownFields rn)
          , forM parsedKnownHash   $ uncurry (solveKnownHash   rn)
          , forM parsedProject     $ uncurry (solveProject     rn)
+         , forM parsedRowHasField $ uncurry (solveRowHasField rn)
          ]
        return $ TcPluginOk solved new
   where
@@ -40,16 +40,16 @@ solve rn given wanted =
     tcs = mkTyConSubst given
 
     parsedAllFields   :: [(Ct, GenLocated CtLoc CAllFields)]
-    parsedHasField    :: [(Ct, GenLocated CtLoc CHasField)]
     parsedKnownFields :: [(Ct, GenLocated CtLoc CKnownFields)]
     parsedKnownHash   :: [(Ct, GenLocated CtLoc CKnownHash)]
     parsedProject     :: [(Ct, GenLocated CtLoc CProject)]
+    parsedRowHasField :: [(Ct, GenLocated CtLoc CRowHasField)]
 
-    parsedAllFields   = parseAll' (withOrig (parseAllFields   tcs rn)) wanted
-    parsedHasField    = parseAll' (withOrig (parseHasField    tcs rn)) wanted
-    parsedKnownFields = parseAll' (withOrig (parseKnownFields tcs rn)) wanted
-    parsedKnownHash   = parseAll' (withOrig (parseKnownHash   tcs rn)) wanted
-    parsedProject     = parseAll' (withOrig (parseProject     tcs rn)) wanted
+    parsedAllFields   = parseAll' (withOrig (parseAllFields      tcs rn)) wanted
+    parsedKnownFields = parseAll' (withOrig (parseKnownFields    tcs rn)) wanted
+    parsedKnownHash   = parseAll' (withOrig (parseKnownHash      tcs rn)) wanted
+    parsedProject     = parseAll' (withOrig (parseProject        tcs rn)) wanted
+    parsedRowHasField = parseAll' (withOrig (parseRowHasField tcs rn)) wanted
 
     _debugInput :: String
     _debugInput = unlines [
@@ -68,10 +68,10 @@ solve rn given wanted =
     _debugParsed = unlines [
           "*** parsed"
         , concat ["parsedAllFields:   ", showSDocUnsafe $ ppr parsedAllFields]
-        , concat ["parsedHasField:    ", showSDocUnsafe $ ppr parsedHasField]
         , concat ["parsedKnownFields: ", showSDocUnsafe $ ppr parsedKnownFields]
         , concat ["parsedKnownHash:   ", showSDocUnsafe $ ppr parsedKnownFields]
         , concat ["parsedProject:     ", showSDocUnsafe $ ppr parsedProject]
+        , concat ["parsedRowHasField: ", showSDocUnsafe $ ppr parsedRowHasField]
         , concat ["tcs (TyConSubst):  ", showSDocUnsafe $ ppr tcs]
         ]
 

--- a/large-anon/test/Test/Infra/Discovery.hs
+++ b/large-anon/test/Test/Infra/Discovery.hs
@@ -1,0 +1,211 @@
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE KindSignatures      #-}
+{-# LANGUAGE PolyKinds           #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE TypeOperators       #-}
+
+module Test.Infra.Discovery (
+     -- * Intersect rows
+     InBothRows(..)
+   , inLeftRow
+   , inRightRow
+   , intersectRows
+     -- * Check for projection
+   , CannotProject
+   , checkCanProject
+   , maybeProject
+     -- * Compute intersection
+   , Intersection(..)
+   , intersect
+     -- * Auxiliary
+   , catMaybeF
+   , pairFst
+   , pairSnd
+   ) where
+
+import Data.Kind
+import Data.Maybe (catMaybes)
+import Data.Typeable
+import GHC.TypeLits
+
+import Data.Record.Anon
+import Data.Record.Anon.Advanced (Record, InRow(InRow))
+import qualified Data.Record.Anon.Advanced as Anon
+import Control.Monad.State
+
+{-------------------------------------------------------------------------------
+  Intersect rows
+
+  NOTE: A constraint @Project r r@ is not completely trivial: it means that
+  there are no shadowed fields.
+-------------------------------------------------------------------------------}
+
+data InBothRows (r1 :: Row k) (r2 :: Row k) (a :: k) where
+  InBothRows :: forall k (n :: Symbol) (r1 :: Row k) (r2 :: Row k) (a :: k).
+       ( KnownSymbol n
+       , RowHasField n r1 a
+       , RowHasField n r2 a
+       )
+    => Proxy n -> InBothRows r1 r2 a
+
+inLeftRow :: InBothRows r1 r2 a -> InRow r1 a
+inLeftRow (InBothRows n) = InRow n
+
+inRightRow :: InBothRows r1 r2 a -> InRow r2 a
+inRightRow (InBothRows n) = InRow n
+
+intersectRows :: forall k (r1 :: Row k) (r2 :: Row k) proxy proxy'.
+     ( KnownFields r1
+     , KnownFields r2
+     , Project r1 r1
+     , Project r2 r2
+     , AllFields r1 Typeable
+     , AllFields r2 Typeable
+     )
+  => proxy r1 -> proxy' r2 -> Record (Maybe :.: InBothRows r1 r2) r2
+intersectRows _ _ =
+    go Anon.reifyProject Anon.reifyProject
+  where
+    go :: Record (InRow r1) r1
+       -> Record (InRow r2) r2
+       -> Record (Maybe :.: InBothRows r1 r2) r2
+    go r1 r2 = Anon.cmap (Proxy @Typeable) (findField r1) r2
+
+    findField :: forall x2.
+          Typeable x2
+       => Record (InRow r1) r1 -> InRow r2 x2 -> (Maybe :.: InBothRows r1 r2) x2
+    findField r1 f = Comp $
+        findMatch . catMaybes $
+          Anon.collapse $ Anon.cmap (Proxy @Typeable) (K . checkIsMatch f) r1
+
+    checkIsMatch :: forall x1 x2.
+         (Typeable x1, Typeable x2)
+      => InRow r2 x2 -> InRow r1 x1 -> Maybe (InBothRows r1 r2 x2)
+    checkIsMatch (InRow x2) (InRow x1) = do
+        Refl <- sameSymbol x1 x2
+        Refl <- eqT :: Maybe (x1 :~: x2)
+        return $ InBothRows x1
+
+    findMatch :: [a] -> Maybe a
+    findMatch []  = Nothing
+    findMatch [a] = Just a
+    findMatch _   = error "checkCanProject: error: multiple matches"
+
+{-------------------------------------------------------------------------------
+  Check for projection
+-------------------------------------------------------------------------------}
+
+-- | If we cannot project, report the missing fields
+type CannotProject = [String]
+
+checkCanProject :: forall k (r1 :: Row k) (r2 :: Row k) proxy proxy'.
+     ( KnownFields r1
+     , KnownFields r2
+     , Project r1 r1
+     , Project r2 r2
+     , AllFields r1 Typeable
+     , AllFields r2 Typeable
+     )
+  => proxy r1 -> proxy' r2 -> Either CannotProject (Reflected (Project r1 r2))
+checkCanProject p1 p2 =
+     uncurry postprocess . flip runState [] . Anon.sequenceA $
+       Anon.zipWith
+         checkInLeft
+         (intersectRows p1 p2)
+         (Anon.reifyKnownFields (Proxy @r2))
+  where
+    checkInLeft ::
+         (Maybe :.: InBothRows r1 r2) x
+      -> K String x
+      -> (State [String] :.: Maybe :.: InRow r1) x
+    checkInLeft (Comp Nothing) (K name) = Comp $ state $ \missing ->
+        (Comp Nothing, name : missing)
+    checkInLeft (Comp (Just inBoth)) _ = Comp $ state $ \missing ->
+        (Comp (Just (inLeftRow inBoth)), missing)
+
+    postprocess ::
+         Record (Maybe :.: InRow r1) r2
+      -> [String]
+      -> Either CannotProject (Reflected (Project r1 r2))
+    postprocess matched missing =
+        maybe (Left missing) (Right . Anon.reflectProject) $
+          Anon.sequenceA matched
+
+maybeProject :: forall k (f :: k -> Type) (r1 :: Row k) (r2 :: Row k) proxy.
+     ( KnownFields r1
+     , KnownFields r2
+     , Project r1  r1
+     , Project r2 r2
+     , AllFields r1  Typeable
+     , AllFields r2 Typeable
+     )
+  => Record f r1 -> proxy r2 -> Either CannotProject (Record f r2)
+maybeProject r1 p = aux <$> checkCanProject r1 p
+  where
+    aux :: Reflected (Project r1 r2) -> Record f r2
+    aux Reflected = Anon.project r1
+
+{-------------------------------------------------------------------------------
+  Compute intersection
+-------------------------------------------------------------------------------}
+
+data Intersection (r1 :: Row k) (r2 :: Row k) where
+    Intersection :: forall k (r1 :: Row k) (r2 :: Row k) (ri :: Row k).
+         ( KnownFields ri
+         , Project r1 ri
+         , Project r2 ri
+         )
+      => Proxy ri -> Intersection r1 r2
+
+intersect :: forall k (r1 :: Row k) (r2 :: Row k) proxy proxy'.
+     ( KnownFields r1
+     , KnownFields r2
+     , Project r1 r1
+     , Project r2 r2
+     , AllFields r1 Typeable
+     , AllFields r2 Typeable
+     )
+  => proxy r1 -> proxy' r2 -> Intersection r1 r2
+intersect p1 p2 =
+    (\(Anon.SomeRecord r) -> aux $ Anon.map pairSnd r) $
+      catMaybeF (intersectRows p1 p2)
+  where
+    aux :: forall ri.
+         KnownFields ri
+      => Record (InBothRows r1 r2) ri -> Intersection r1 r2
+    aux r =
+        case (project1, project2) of
+          (Reflected, Reflected) -> Intersection (Proxy @ri)
+      where
+        project1 :: Reflected (Project r1 ri)
+        project1 = Anon.reflectProject $ Anon.map inLeftRow r
+
+        project2 :: Reflected (Project r2 ri)
+        project2 = Anon.reflectProject $ Anon.map inRightRow r
+
+{-------------------------------------------------------------------------------
+  Auxiliary
+-------------------------------------------------------------------------------}
+
+catMaybeF :: KnownFields r => Record (Maybe :.: f) r -> Anon.SomeRecord f
+catMaybeF =
+      Anon.someRecord
+    . catMaybes
+    . map distrib
+    . Anon.toList
+    . Anon.map (K . Some)
+  where
+    distrib :: (String, Some (Maybe :.: f)) -> Maybe (String, Some f)
+    distrib (_, Some (Comp Nothing))   = Nothing
+    distrib (n, Some (Comp (Just fx))) = Just (n, Some fx)
+
+pairFst :: Product f g x -> f x
+pairFst (Pair fx _) = fx
+
+pairSnd :: Product f g x -> g x
+pairSnd (Pair _ gx) = gx
+
+

--- a/large-anon/test/Test/Infra/DynRecord/Advanced.hs
+++ b/large-anon/test/Test/Infra/DynRecord/Advanced.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ConstraintKinds     #-}
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE GADTs               #-}
@@ -13,95 +14,28 @@
 --
 -- > import qualified Test.Infra.DynRecord.Advanced as Dyn
 module Test.Infra.DynRecord.Advanced (
-    -- * Projection to known row
-    toLens
-  , toRecord
     -- * Type inference
-  , ValidField(..)
+    ValidField(..)
+  , IsValue(..)
   , SomeRecord(..)
   , inferType
+    -- * Lens
+  , toLens
+  , toRecord
   ) where
 
 import Data.Bifunctor
 import Data.Kind
 import Data.Record.Generic
 import Data.SOP.Constraint
+import Data.Typeable
 
 import Data.Record.Anon
-import Data.Record.Anon.Advanced (Record, CannotProject(..))
+import Data.Record.Anon.Advanced (Record)
 import qualified Data.Record.Anon.Advanced as Anon
 
+import Test.Infra.Discovery
 import Test.Infra.DynRecord
-
-{-------------------------------------------------------------------------------
-  Projection to known row
--------------------------------------------------------------------------------}
-
--- | Internal auxiliary
---
--- Unlike 'toLens', this does not do any parsing or unparsing. This means that
--- we avoid type class constraints here, avoiding unnecessary constraints in
--- 'toRecord'.
-toLens' :: forall k (r :: Row k) proxy.
-     KnownFields r
-  => proxy r
-  -> DynRecord
-  -> Either CannotProject
-            (Record (K Value) r, Record (K Value) r -> DynRecord)
-toLens' p (DynRecord r) =
-    case Anon.someRecord $ map (Some . K) r of
-      Some record ->
-        case Anon.reflectKnownFields (Anon.map (mapKK fst) record) of
-          Reflected -> withSomeRecord (Anon.map (mapKK snd) record)
-  where
-    -- @r'@ is the "inferred" row of the actual 'DynRecord'
-    -- (as opposed to the expected row specified as an argument)
-    withSomeRecord :: forall (r' :: Row k).
-          KnownFields r'
-       => Record (K Value) r'
-       -> Either CannotProject
-                 (Record (K Value) r, Record (K Value) r -> DynRecord)
-    withSomeRecord record =
-        (fmap setter  . ($ record)) <$> makeLens record p
-
-    setter ::
-         KnownFields r'
-      => (Record (K Value) r -> Record (K Value) r')
-      -> Record (K Value) r -> DynRecord
-    setter f = DynRecord . Anon.toList . f
-
--- | Lens to record of known type
---
--- If the expected type of the record is known a priori, there is no need for a
--- separate type discovery step: we just check if the 'DynRecord' can be made
--- fit into the expected mould.
-toLens ::
-     ( KnownFields r
-     , AllFields   r (FromValue f)
-     , AllFields   r (ToValue   f)
-     )
-  => proxy r
-  -> DynRecord
-  -> Either (Either CannotProject ParseError)
-            (Record f r, Record f r -> DynRecord)
-toLens p = distrib . fmap (bimap fromValues (. toValues)) . toLens' p
-  where
-    distrib :: Either a (Either b c, d) -> Either (Either a b) (c, d)
-    distrib (Left a)             = Left (Left a)
-    distrib (Right (Left b, _))  = Left (Right b)
-    distrib (Right (Right c, d)) = Right (c, d)
-
-toRecord ::
-     (KnownFields r, AllFields r (FromValue f))
-  => proxy r
-  -> DynRecord
-  -> Either (Either CannotProject ParseError) (Record f r)
-toRecord p = distrib . fmap (fromValues . fst) . toLens' p
-  where
-    distrib :: Either a (Either b c) -> Either (Either a b) c
-    distrib (Left a)          = Left (Left a)
-    distrib (Right (Left b))  = Left (Right b)
-    distrib (Right (Right c)) = Right c
 
 {-------------------------------------------------------------------------------
   Type inference
@@ -109,77 +43,108 @@ toRecord p = distrib . fmap (fromValues . fst) . toLens' p
 
 data ValidField (f :: k -> Type) (x :: k) where
   ValidField ::
-       ( Show     (f x)
+       ( Typeable    x
+       , Show     (f x)
        , Eq       (f x)
        , ToValue   f x
-       , FromValue f x
        )
-    => String -> f x -> ValidField f x
+    => f x -> ValidField f x
+
+class IsValue f where
+  isValue :: Value -> Some (ValidField f)
 
 data SomeRecord (f :: k -> Type) where
   SomeRecord :: forall k (f :: k -> Type) (r :: Row k).
        ( KnownFields r
+       , Project r r
+       , AllFields r Typeable
        , AllFields r (Compose Show f)
        , AllFields r (Compose Eq   f)
-       , AllFields r (FromValue    f)
        , AllFields r (ToValue      f)
        )
     => Record f r -> SomeRecord f
 
-deriving instance Show (SomeRecord f)
-
-inferType :: forall k (f :: k -> Type).
-     (String -> Value -> Some (ValidField f))
-  -> DynRecord
-  -> SomeRecord f
-inferType mkField (DynRecord r) =
-    case Anon.someRecord $ map (uncurry mkField) r of
-      Some record ->
-        case Anon.reflectKnownFields $ Anon.map fieldName record of
-          Reflected -> withSomeRecord record
+inferType :: forall k (f :: k -> Type). IsValue f => DynRecord -> SomeRecord f
+inferType (DynRecord r) =
+     case Anon.someRecord (map (second isValue) r) of
+       Anon.SomeRecord record ->
+         case Anon.reflectProject (Anon.map pairFst record) of
+           Reflected -> withSomeRecord (Anon.map pairSnd record)
   where
-    withSomeRecord :: KnownFields r => Record (ValidField f) r -> SomeRecord f
+    withSomeRecord ::
+         ( KnownFields r
+         , Project r r
+         )
+      => Record (ValidField f) r -> SomeRecord f
     withSomeRecord record =
-        case ( Anon.reflectAllFields (Anon.map dictShow      record)
+        case ( Anon.reflectAllFields (Anon.map dictTypeable  record)
+             , Anon.reflectAllFields (Anon.map dictShow      record)
              , Anon.reflectAllFields (Anon.map dictEq        record)
-             , Anon.reflectAllFields (Anon.map dictFromValue record)
              , Anon.reflectAllFields (Anon.map dictToValue   record)
              ) of
           (Reflected, Reflected, Reflected, Reflected) ->
             SomeRecord (Anon.map fieldValue record)
 
-    fieldName  :: ValidField f x -> K String x
     fieldValue :: ValidField f x -> f x
+    fieldValue (ValidField value) = value
 
-    fieldName  (ValidField name _    ) = K name
-    fieldValue (ValidField _    value) = value
+    dictTypeable :: ValidField f x -> Dict Typeable         x
+    dictShow     :: ValidField f x -> Dict (Compose Show f) x
+    dictEq       :: ValidField f x -> Dict (Compose Eq   f) x
+    dictToValue  :: ValidField f x -> Dict (ToValue      f) x
 
-    dictShow      :: ValidField f x -> Dict (Compose Show f) x
-    dictEq        :: ValidField f x -> Dict (Compose Eq   f) x
-    dictFromValue :: ValidField f x -> Dict (FromValue    f) x
-    dictToValue   :: ValidField f x -> Dict (ToValue      f) x
-
-    dictShow      (ValidField _ _) = Dict
-    dictEq        (ValidField _ _) = Dict
-    dictFromValue (ValidField _ _) = Dict
-    dictToValue   (ValidField _ _) = Dict
+    dictTypeable (ValidField _) = Dict
+    dictShow     (ValidField _) = Dict
+    dictEq       (ValidField _) = Dict
+    dictToValue  (ValidField _) = Dict
 
 {-------------------------------------------------------------------------------
-  Auxiliary: try to construct a lens
+  Projection to known row
 -------------------------------------------------------------------------------}
 
-makeLens :: forall k (r :: Row k) (r' :: Row k) (a :: Type) proxy proxy'.
-     (KnownFields r, KnownFields r')
-  => proxy   r
-  -> proxy'  r'
-  -> Either CannotProject
-            (Record (K a) r -> ( Record (K a) r'
-                               , Record (K a) r' -> Record (K a) r
-                               ))
-makeLens pr pr' = aux <$> Anon.reflectProject pr pr'
+-- | Lens to record over some known row @r@
+toLens :: forall k (f :: k -> Type) (r :: Row k) proxy.
+     ( IsValue f
+     , KnownFields r
+     , Project r r
+     , AllFields r Typeable
+     )
+  => proxy r
+  -> DynRecord
+  -> Either CannotProject (Record f r, Record f r -> DynRecord)
+toLens p = \r ->
+    -- In order to be able to check if we can project to the known row @r@,
+    -- we must first to type inference on the @DynRecord@. /If/ this succeeds,
+    -- we know the types line up, and there can be no further type errors
+    -- (there is no need for a separate parsing step).
+    case inferType r of
+      SomeRecord r' ->
+        fmap (withSomeRecord r') $ checkCanProject r' p
   where
-    aux :: Reflected (Project (K a) r r')
-        -> Record (K a) r
-        -> (Record (K a) r', Record (K a) r' -> Record (K a) r)
-    aux Reflected = Anon.lens
+    -- @r'@ is the row inferred for the 'DynRecord'
+    withSomeRecord :: forall (r' :: Row k).
+         ( KnownFields r'
+         , AllFields r' (ToValue f)
+         )
+      => Record f r'
+      -> Reflected (Project r' r)
+      -> (Record f r, Record f r -> DynRecord)
+    withSomeRecord r Reflected = (
+          getter
+        , DynRecord . Anon.toList . toValues . setter
+        )
+      where
+        getter :: Record f r
+        setter :: Record f r -> Record f r'
+        (getter, setter) = Anon.lens r
 
+toRecord :: forall k (r :: Row k) (f :: k -> *) proxy.
+     ( IsValue f
+     , KnownFields r
+     , Project r r
+     , AllFields r Typeable
+     )
+  => proxy r
+  -> DynRecord
+  -> Either CannotProject (Record f r)
+toRecord p = fmap fst . toLens p

--- a/large-anon/test/Test/Infra/MarkStrictness.hs
+++ b/large-anon/test/Test/Infra/MarkStrictness.hs
@@ -18,7 +18,10 @@ module Test.Infra.MarkStrictness (
 import Data.Kind
 import Data.SOP.BasicFunctors
 
+import Data.Record.Anon
+
 import Test.Infra.DynRecord
+import Test.Infra.DynRecord.Advanced
 
 {-------------------------------------------------------------------------------
   Definition
@@ -48,13 +51,16 @@ instance Eq a => Eq (Boxed (Lazy a)) where
   Interop with 'DynRecord'
 -------------------------------------------------------------------------------}
 
-instance FromValue I a => FromValue Boxed (Lazy a) where
-  fromValue = fmap (BoxLazy . unI) . fromValue
-instance FromValue I a => FromValue Boxed (Strict a) where
-  fromValue = fmap (BoxStrict . unI) . fromValue
-
 instance ToValue I a => ToValue Boxed (Lazy a) where
   toValue (BoxLazy x) = toValue (I x)
 instance ToValue I a => ToValue Boxed (Strict a) where
   toValue (BoxStrict x) = toValue (I x)
 
+-- | Type inference for a value
+--
+-- Just for the example, we infer all 'Int' fields are strict and all other
+-- fields as lazy.
+instance IsValue Boxed where
+  isValue (VI x) = Some $ ValidField $ BoxStrict x
+  isValue (VB x) = Some $ ValidField $ BoxLazy   x
+  isValue (VC x) = Some $ ValidField $ BoxLazy   x

--- a/large-anon/test/Test/Sanity/AllFields.hs
+++ b/large-anon/test/Test/Sanity/AllFields.hs
@@ -39,22 +39,22 @@ recordA =
 --
 -- Normally this record would be constructed by the plugin (for 'RecordDicts'
 -- instance).
-recordD :: Record (Dict Show :.: I) [ "a" := Int, "b" := Bool, "c" := Char ]
+recordD :: Record (Dict (Compose Show I)) [ "a" := Int, "b" := Bool, "c" := Char ]
 recordD =
-      Anon.insert #a (Comp Dict)
-    $ Anon.insert #b (Comp Dict)
-    $ Anon.insert #c (Comp Dict)
+      Anon.insert #a Dict
+    $ Anon.insert #b Dict
+    $ Anon.insert #c Dict
     $ Anon.empty
 
 {-------------------------------------------------------------------------------
   Auxiliary
 -------------------------------------------------------------------------------}
 
-showFields :: Record (Dict Show :.: f) r -> Record f r -> [String]
+showFields :: Record (Dict (Compose Show f)) r -> Record f r -> [String]
 showFields ds xs = Anon.collapse $ Anon.zipWith aux ds xs
   where
-    aux :: (Dict Show :.: f) x -> f x -> K String x
-    aux (Comp Dict) x = K (show x)
+    aux :: (Dict (Compose Show f)) x -> f x -> K String x
+    aux Dict x = K (show x)
 
 {-------------------------------------------------------------------------------
   Tests proper
@@ -73,7 +73,7 @@ test_manual = do
 test_derived :: Assertion
 test_derived = do
      assertEqual "" expected $
-       showFields (Anon.reifyAllFields (Proxy @Show)) recordA
+       showFields (Anon.reifyAllFields (Proxy @(Compose Show I))) recordA
   where
     expected :: [String]
     expected = ["I 1", "I True", "I 'a'"]

--- a/large-anon/test/Test/Sanity/CheckCanProject.hs
+++ b/large-anon/test/Test/Sanity/CheckCanProject.hs
@@ -1,0 +1,53 @@
+{-# LANGUAGE DataKinds        #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators    #-}
+
+{-# OPTIONS_GHC -fplugin=Data.Record.Anon.Plugin #-}
+
+module Test.Sanity.CheckCanProject (tests) where
+
+import Data.Typeable
+
+import Data.Record.Anon
+import Data.Record.Anon.Advanced (Record)
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import Test.Infra.Discovery
+
+tests :: TestTree
+tests = testGroup "Test.Sanity.CheckCanProject" [
+      testCase "checkCanProject" test_checkCanProject
+    ]
+
+test_checkCanProject :: Assertion
+test_checkCanProject = do
+    case maybeProject example1 (Proxy @Row2) of
+      Left  _  -> assertFailure "Should be able to project to Row2"
+      Right r1 -> assertEqual "Should be equal" r1 example2
+
+    case maybeProject example1 (Proxy @Row3) of
+      Left missing -> assertEqual "missing" ["c"] missing
+      Right _      -> assertFailure "Should not be able to project to Row3"
+
+{-------------------------------------------------------------------------------
+  Example values
+-------------------------------------------------------------------------------}
+
+type Row1 = [ "a" := Int, "b" := Bool, "c" := Char ]
+type Row2 = [ "c" := Char, "a" := Int ]
+type Row3 = [ "c" := Bool, "a" := Int ]
+
+example1 :: Record I Row1
+example1 = ANON_F {
+      a = I 1
+    , b = I True
+    , c = I 'a'
+    }
+
+example2 :: Record I Row2
+example2 = ANON_F {
+      c = I 'a'
+    , a = I 1
+    }

--- a/large-anon/test/Test/Sanity/Intersection.hs
+++ b/large-anon/test/Test/Sanity/Intersection.hs
@@ -1,0 +1,74 @@
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeOperators       #-}
+
+{-# OPTIONS_GHC -fplugin=Data.Record.Anon.Plugin #-}
+
+module Test.Sanity.Intersection (tests) where
+
+import Data.SOP.BasicFunctors
+
+import Data.Record.Anon
+import Data.Record.Anon.Advanced (Record)
+import qualified Data.Record.Anon.Advanced as Anon
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import Test.Infra.Discovery
+
+tests :: TestTree
+tests = testGroup "Test.Sanity.Intersection" [
+      testCase "intersection" test_intersection
+    ]
+
+test_intersection :: Assertion
+test_intersection =
+    case intersect example1 example2 of
+      Intersection p -> go p
+  where
+    go :: forall ri.
+         (Project Row1 ri, Project Row2 ri)
+      => Proxy ri -> Assertion
+    go _ = do
+        assertEqual "1" example1' $
+          Anon.inject projected2 example1
+        assertEqual "2" example2' $
+          Anon.inject projected1 example2
+      where
+        projected1, projected2 :: Record I ri
+        projected1 = Anon.project example1
+        projected2 = Anon.project example2
+
+{-------------------------------------------------------------------------------
+  Example values
+
+  Row1 only have field "a" in common: field "b" is absent in Row2,
+  and field "c" has a different type
+-------------------------------------------------------------------------------}
+
+type Row1 = [ "a" := Int, "b" := Bool, "c" := Char ]
+type Row2 = [ "c" := Double, "a" := Int ]
+
+example1, example1' :: Record I Row1
+example1 = ANON_F {
+      a = I 1
+    , b = I True
+    , c = I 'a'
+    }
+example1' =  ANON_F {
+      a = I 2
+    , b = I True
+    , c = I 'a'
+    }
+
+example2, example2' :: Record I Row2
+example2 = ANON_F {
+      c = I 3.14
+    , a = I 2
+    }
+example2' = ANON_F {
+      c = I 3.14
+    , a = I 1
+    }

--- a/large-anon/test/Test/Sanity/Merging.hs
+++ b/large-anon/test/Test/Sanity/Merging.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE TypeFamilies     #-}
 {-# LANGUAGE TypeOperators    #-}
 
+{-# OPTIONS_GHC -Wno-redundant-constraints #-}
 {-# OPTIONS_GHC -fplugin=Data.Record.Anon.Plugin #-}
 
 module Test.Sanity.Merging (tests) where

--- a/large-anon/test/TestLargeAnon.hs
+++ b/large-anon/test/TestLargeAnon.hs
@@ -6,10 +6,12 @@ import qualified Test.Prop.Record.Combinators.Constrained
 import qualified Test.Prop.Record.Combinators.Simple
 import qualified Test.Sanity.AllFields
 import qualified Test.Sanity.Applicative
+import qualified Test.Sanity.CheckCanProject
 import qualified Test.Sanity.Discovery
 import qualified Test.Sanity.DuplicateFields
 import qualified Test.Sanity.Generics
 import qualified Test.Sanity.HasField
+import qualified Test.Sanity.Intersection
 import qualified Test.Sanity.Lens
 import qualified Test.Sanity.Merging
 import qualified Test.Sanity.PolyKinds
@@ -31,9 +33,11 @@ main = defaultMain $ testGroup "large-anon" [
         , Test.Sanity.Applicative.tests
         , Test.Sanity.Simple.tests
         , Test.Sanity.PolyKinds.tests
+        , Test.Sanity.CheckCanProject.tests
         , Test.Sanity.Discovery.tests
         , Test.Sanity.SrcPlugin.WithoutTypelet.tests
         , Test.Sanity.SrcPlugin.WithTypelet.tests
+        , Test.Sanity.Intersection.tests
         ]
     , testGroup "Prop" [
           Test.Prop.Record.Combinators.Simple.tests


### PR DESCRIPTION
This makes a few changes to the `Runtime`:

- No polymorphism over proxies. Since these are internal classes anyway,
  this just leads to additional complexity for benefit.
- The `RecordHasClass` no longer has a functor argument. This means that
  evidence of `RecordHasClass` is now more powerful than it was before
  (for _any_ `f`..).
- RecordHasClass no longer refers to any records: it just gives the
  index of the field. It therefore has been renamed to `RowHasField`.
- Remove the `f` parameter from `Project` as well; this makes it
  possible to define very nice `reify` and `reflect` functions for
  `Project`, now entirely in line with the others. Very pretty :)