### PR TITLE
Rename `lens` to `recordLens`

### DIFF
--- a/large-anon/large-anon.cabal
+++ b/large-anon/large-anon.cabal
@@ -140,11 +140,11 @@ test-suite test-large-anon
       Test.Sanity.Generics
       Test.Sanity.HasField
       Test.Sanity.Intersection
-      Test.Sanity.Lens
       Test.Sanity.Merging
       Test.Sanity.Named.Record1
       Test.Sanity.Named.Record2
       Test.Sanity.PolyKinds
+      Test.Sanity.RecordLens
       Test.Sanity.Simple
       Test.Sanity.SrcPlugin.WithoutTypelet
       Test.Sanity.SrcPlugin.WithTypelet

--- a/large-anon/src/Data/Record/Anon/Advanced.hs
+++ b/large-anon/src/Data/Record/Anon/Advanced.hs
@@ -32,7 +32,7 @@ module Data.Record.Anon.Advanced (
   , merge
   , project
   , inject
-  , lens
+  , recordLens
     -- * Combinators
     -- ** " Functor "
   , map
@@ -357,8 +357,10 @@ inject = A.inject
 --
 -- See 'project' for examples ('project' is just the lens getter, without the
 -- setter).
-lens :: Project r r' => Record f r -> (Record f r', Record f r' -> Record f r)
-lens = A.lens
+recordLens ::
+     Project r r'
+  => Record f r -> (Record f r', Record f r' -> Record f r)
+recordLens = A.recordLens
 
 {-------------------------------------------------------------------------------
   Combinators

--- a/large-anon/src/Data/Record/Anonymous/Advanced.hs
+++ b/large-anon/src/Data/Record/Anonymous/Advanced.hs
@@ -24,7 +24,7 @@ module Data.Record.Anonymous.Advanced (
   , Record.get
   , Record.set
   , Record.merge
-  , Record.lens
+  , Record.recordLens
   , Record.project
   , Record.inject
   , Record.applyPending

--- a/large-anon/src/Data/Record/Anonymous/Internal/Record.hs
+++ b/large-anon/src/Data/Record/Anonymous/Internal/Record.hs
@@ -36,7 +36,7 @@ module Data.Record.Anonymous.Internal.Record (
   , get
   , set
   , merge
-  , lens
+  , recordLens
   , project
   , inject
   , applyPending
@@ -178,10 +178,10 @@ merge :: Record f r -> Record f r' -> Record f (Merge r r')
 merge (toCanonical -> r) (toCanonical -> r') =
     unsafeFromCanonical $ r <> r'
 
-lens :: forall f r r'.
+recordLens :: forall f r r'.
      Project r r'
   => Record f r -> (Record f r', Record f r' -> Record f r)
-lens = \(toCanonical -> r) ->
+recordLens = \(toCanonical -> r) ->
     bimap getter setter $
       Canon.lens (projectIndices (Proxy @r) (Proxy @r')) r
   where
@@ -195,13 +195,13 @@ lens = \(toCanonical -> r) ->
 --
 -- This is just the 'lens' getter.
 project :: Project r r' => Record f r -> Record f r'
-project = fst . lens
+project = fst . recordLens
 
 -- | Inject subrecord
 --
--- This is just the 'lens' setter.
+-- This is just the 'recordLens' setter.
 inject :: Project r r' => Record f r' -> Record f r -> Record f r
-inject small = ($ small) . snd . lens
+inject small = ($ small) . snd . recordLens
 
 applyPending :: Record f r -> Record f r
 applyPending (toCanonical -> r) = unsafeFromCanonical r

--- a/large-anon/src/Data/Record/Anonymous/Simple.hs
+++ b/large-anon/src/Data/Record/Anonymous/Simple.hs
@@ -137,7 +137,7 @@ merge r r' = fromAdvanced $ Adv.merge (toAdvanced r) (toAdvanced r')
 lens :: Project r r' => Record r -> (Record r', Record r' -> Record r)
 lens =
       bimap fromAdvanced (\f -> fromAdvanced . f . toAdvanced)
-    . Adv.lens
+    . Adv.recordLens
     . toAdvanced
 
 project :: Project r r' => Record r -> Record r'

--- a/large-anon/test/Test/Infra/DynRecord/Advanced.hs
+++ b/large-anon/test/Test/Infra/DynRecord/Advanced.hs
@@ -136,7 +136,7 @@ toLens p = \r ->
       where
         getter :: Record f r
         setter :: Record f r -> Record f r'
-        (getter, setter) = Anon.lens r
+        (getter, setter) = Anon.recordLens r
 
 toRecord :: forall k (r :: Row k) (f :: k -> *) proxy.
      ( IsValue f

--- a/large-anon/test/Test/Sanity/DuplicateFields.hs
+++ b/large-anon/test/Test/Sanity/DuplicateFields.hs
@@ -238,8 +238,8 @@ test_update = do
     assertEqual "diff" (upd interspersedDiffType) $
       setDiff new
   where
-    (_, setSame) = Anon.lens interspersedSameType
-    (_, setDiff) = Anon.lens interspersedDiffType
+    (_, setSame) = Anon.recordLens interspersedSameType
+    (_, setDiff) = Anon.recordLens interspersedDiffType
 
     upd :: HasField "d" (Record I r) (I [Double]) => Record I r -> Record I r
     upd r = Anon.set #d (I [1.618]) r

--- a/large-anon/test/Test/Sanity/RecordLens.hs
+++ b/large-anon/test/Test/Sanity/RecordLens.hs
@@ -4,7 +4,7 @@
 
 {-# OPTIONS_GHC -fplugin=Data.Record.Anon.Plugin #-}
 
-module Test.Sanity.Lens (tests) where
+module Test.Sanity.RecordLens (tests) where
 
 import Test.Tasty
 import Test.Tasty.HUnit
@@ -14,7 +14,7 @@ import Data.Record.Anon.Advanced (Record)
 import qualified Data.Record.Anon.Advanced as Anon
 
 tests :: TestTree
-tests = testGroup "Test.Sanity.Lens" [
+tests = testGroup "Test.Sanity.RecordLens" [
       testGroup "Isomorphic projections" [
           testCase "id"      test_id
         , testCase "reorder" test_reorder
@@ -79,7 +79,7 @@ test_merge = assertEqual "" recordA $ Anon.project recordWithMerge
 
 test_lens :: Assertion
 test_lens = do
-    let (getter, setter) = Anon.lens recordA
+    let (getter, setter) = Anon.recordLens recordA
     assertEqual "get" recordB $
       getter
     assertEqual "set" (Anon.set #c (I 2) recordA) $

--- a/large-anon/test/TestLargeAnon.hs
+++ b/large-anon/test/TestLargeAnon.hs
@@ -12,9 +12,9 @@ import qualified Test.Sanity.DuplicateFields
 import qualified Test.Sanity.Generics
 import qualified Test.Sanity.HasField
 import qualified Test.Sanity.Intersection
-import qualified Test.Sanity.Lens
 import qualified Test.Sanity.Merging
 import qualified Test.Sanity.PolyKinds
+import qualified Test.Sanity.RecordLens
 import qualified Test.Sanity.Simple
 import qualified Test.Sanity.SrcPlugin.WithoutTypelet
 import qualified Test.Sanity.SrcPlugin.WithTypelet
@@ -26,7 +26,7 @@ main = defaultMain $ testGroup "large-anon" [
           Test.Sanity.HasField.tests
         , Test.Sanity.Generics.tests
         , Test.Sanity.Merging.tests
-        , Test.Sanity.Lens.tests
+        , Test.Sanity.RecordLens.tests
         , Test.Sanity.DuplicateFields.tests
         , Test.Sanity.TypeLevelMetadata.tests
         , Test.Sanity.AllFields.tests


### PR DESCRIPTION
This makes we can more easily later add a `fieldLens` (in terms of `HasField`) if we wanted to.