### PR TITLE
Add Cabal to setup-depends

### DIFF
--- a/typelet/typelet.cabal
+++ b/typelet/typelet.cabal
@@ -27,6 +27,7 @@ custom-setup
     setup-depends:
         base >= 4 && <5
       , cabal-doctest >= 1 && <1.1
+      , Cabal < 4
 
 library
     exposed-modules:


### PR DESCRIPTION
I am using typelet with stack, but found the following error.

```
Warning: typelet
         has a setup-depends field, but it does not mention a Cabal dependency. This is likely to cause build errors.
typelet   > [1 of 2] Compiling Main             ( /tmp/stack-2f72c5fe4e2ab65c/typelet-0.1.1.0/Setup.hs, /tmp/stack-2f72c5fe4e2ab65c/typelet-0.1.1.0/.stack-work/dist/x86_64-linux-tinfo6/Cabal-3.2.1.0/setup/Main.o )
typelet   > [2 of 2] Compiling StackSetupShim   ( /home/jiasen/.stack/setup-exe-src/setup-shim-mPHDZzAJ.hs, /tmp/stack-2f72c5fe4e2ab65c/typelet-0.1.1.0/.stack-work/dist/x86_64-linux-tinfo6/Cabal-3.2.1.0/setup/StackSetupShim.o )
typelet   > 
typelet   > /home/jiasen/.stack/setup-exe-src/setup-shim-mPHDZzAJ.hs:3:1: error:
typelet   >     Could not load module ‘Distribution.PackageDescription’
typelet   >     It is a member of the hidden package ‘Cabal-3.2.1.0’.
typelet   >     You can run ‘:set -package Cabal’ to expose it.
typelet   >     (Note: this unloads all the modules in the current scope.)
typelet   >     Use -v (or `:set -v` in ghci) to see a list of the files searched for.
typelet   >   |
typelet   > 3 | import Distribution.PackageDescription (PackageDescription, emptyHookedBuildInfo)
typelet   >   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

My stack.yaml
``` yaml
resolver: lts-18.6
packages:
- .
extra-deps:
- large-anon-0.1.0.0
- large-generics-0.2.0.0
- ghc-tcplugin-api-0.7.1.0
- typelet-0.1.1.0
```

So I add Cabal to the setup_depends field in this PR.