### PR TITLE
WIP: work towards making large-anon compile on GHC 9.2

### DIFF
--- a/large-anon/large-anon.cabal
+++ b/large-anon/large-anon.cabal
@@ -156,7 +156,6 @@ test-suite test-large-anon
     , optics-core
     , parsec
     , QuickCheck
-    , record-dot-preprocessor
     , sop-core
     , tasty
     , tasty-hunit
@@ -165,8 +164,12 @@ test-suite test-large-anon
     , typelet
     , validation-selective
 
-      -- required when using record-dot-preprocessor
-    , record-hasfield
+  if impl(ghc < 9.2.0)
+    build-depends:
+        record-dot-preprocessor
+        -- required when using record-dot-preprocessor
+      , record-hasfield
+
   ghc-options:
       -Wall
       -Wredundant-constraints

--- a/large-anon/src/Data/Record/Anon/Internal/Plugin/TC/Constraints/RowHasField.hs
+++ b/large-anon/src/Data/Record/Anon/Internal/Plugin/TC/Constraints/RowHasField.hs
@@ -76,18 +76,21 @@ parseRowHasField ::
   -> Ct
   -> ParseResult Void (GenLocated CtLoc CRowHasField)
 parseRowHasField tcs rn@ResolvedNames{..} =
-    parseConstraint' clsRowHasField $ \[k, n, r, a] -> do
-      label  <- ParsedRow.parseFieldLabel n
-      fields <- ParsedRow.parseFields tcs rn r
-
-      return $ CRowHasField {
-          hasFieldLabel     = label
-        , hasFieldRecord    = fields
-        , hasFieldTypeKind  = k
-        , hasFieldTypeLabel = n
-        , hasFieldTypeRow   = r
-        , hasFieldTypeField = a
-        }
+    parseConstraint' clsRowHasField $ \ args ->
+      case args of
+        [k, n, r, a] -> do
+          label  <- ParsedRow.parseFieldLabel n
+          fields <- ParsedRow.parseFields tcs rn r
+          return $ CRowHasField {
+              hasFieldLabel     = label
+            , hasFieldRecord    = fields
+            , hasFieldTypeKind  = k
+            , hasFieldTypeLabel = n
+            , hasFieldTypeRow   = r
+            , hasFieldTypeField = a
+            }
+        _ -> pprPanic "parseRowHasField: expected 4 arguments" $
+               ( text "args:" <+> ppr args )
 
 {-------------------------------------------------------------------------------
   Evidence

--- a/large-anon/src/Data/Record/Anon/Internal/Plugin/TC/Constraints/SubRow.hs
+++ b/large-anon/src/Data/Record/Anon/Internal/Plugin/TC/Constraints/SubRow.hs
@@ -67,16 +67,20 @@ parseSubRow ::
   -> Ct
   -> ParseResult Void (GenLocated CtLoc CSubRow)
 parseSubRow tcs rn@ResolvedNames{..} =
-    parseConstraint' clsSubRow $ \[typeKind, typeLHS, typeRHS] -> do
-      fieldsLHS <- ParsedRow.parseFields tcs rn typeLHS
-      fieldsRHS <- ParsedRow.parseFields tcs rn typeRHS
-      return $ CSubRow {
-            subrowParsedLHS = fieldsLHS
-          , subrowParsedRHS = fieldsRHS
-          , subrowTypeLHS   = typeLHS
-          , subrowTypeRHS   = typeRHS
-          , subrowTypeKind  = typeKind
-          }
+    parseConstraint' clsSubRow $ \ args ->
+      case args of
+        [typeKind, typeLHS, typeRHS] -> do
+          fieldsLHS <- ParsedRow.parseFields tcs rn typeLHS
+          fieldsRHS <- ParsedRow.parseFields tcs rn typeRHS
+          return $ CSubRow {
+                subrowParsedLHS = fieldsLHS
+              , subrowParsedRHS = fieldsRHS
+              , subrowTypeLHS   = typeLHS
+              , subrowTypeRHS   = typeRHS
+              , subrowTypeKind  = typeKind
+              }
+        _ -> pprPanic "parseSubRow: expected 3 arguments" $
+               text "args" <+> ppr args
 
 {-------------------------------------------------------------------------------
   Evidence

--- a/large-anon/src/Data/Record/Anon/Internal/Plugin/TC/GhcTcPluginAPI.hs
+++ b/large-anon/src/Data/Record/Anon/Internal/Plugin/TC/GhcTcPluginAPI.hs
@@ -18,10 +18,6 @@ module Data.Record.Anon.Internal.Plugin.TC.GhcTcPluginAPI (
   , module GHC.Core.Make
   , module GHC.Utils.Outputable
 
-    -- * Additional exports
-  , splitAppTys
-  , unpackFS
-
     -- * New functonality
   , isCanonicalVarEq
   ) where
@@ -38,26 +34,18 @@ import GHC.Core.Make
 import GHC.Utils.Outputable
 
 #if __GLASGOW_HASKELL__ >= 808 &&  __GLASGOW_HASKELL__ < 810
-import FastString (unpackFS)
 import TcRnTypes (Ct(..))
-import Type (splitAppTys)
 #endif
 
 #if __GLASGOW_HASKELL__ >= 810 &&  __GLASGOW_HASKELL__ < 900
 import Constraint (Ct(..))
-import FastString (unpackFS)
-import Type (splitAppTys)
 #endif
 
 #if __GLASGOW_HASKELL__ >= 900 &&  __GLASGOW_HASKELL__ < 902
-import GHC.Core.Type (splitAppTys)
-import GHC.Data.FastString (unpackFS)
 import GHC.Tc.Types.Constraint (Ct(..))
 #endif
 
 #if __GLASGOW_HASKELL__ >= 902
-import GHC.Core.Type (splitAppTys)
-import GHC.Data.FastString (unpackFS)
 import GHC.Tc.Types.Constraint (Ct(..), CanEqLHS(..))
 #endif
 

--- a/large-anon/src/Data/Record/Anon/Internal/Plugin/TC/NameResolution.hs
+++ b/large-anon/src/Data/Record/Anon/Internal/Plugin/TC/NameResolution.hs
@@ -76,7 +76,7 @@ nameResolution = do
 
 getModule :: MonadTcPlugin m => String -> String -> m Module
 getModule pkg modl = do
-    r <- findImportedModule (mkModuleName modl) (Just (fsLit pkg))
+    r <- findImportedModule (mkModuleName modl) (OtherPkg $ stringToUnitId pkg)
     case r of
       Found _ m  -> return m
       _otherwise -> panic $ "Could not find " ++ modl ++ " in package " ++ pkg

--- a/large-anon/src/Data/Record/Anon/Internal/Util/SmallHashMap.hs
+++ b/large-anon/src/Data/Record/Anon/Internal/Util/SmallHashMap.hs
@@ -47,7 +47,7 @@ import qualified Data.Map.Strict as Map
 newtype Hashed k = Hashed k
   deriving (Show)
 
-instance (Hashable k, Eq k) => Eq (Hashed k) where
+instance Hashable k => Eq (Hashed k) where
   Hashed a == Hashed b = and [
       hash a == hash b
     ,      a ==      b

--- a/large-anon/test/Test/Infra/DynRecord/Advanced.hs
+++ b/large-anon/test/Test/Infra/DynRecord/Advanced.hs
@@ -138,7 +138,7 @@ toLens p = \r ->
         setter :: Record f r -> Record f r'
         (getter, setter) = Anon.lens r
 
-toRecord :: forall k (r :: Row k) (f :: k -> *) proxy.
+toRecord :: forall k (r :: Row k) (f :: k -> Type) proxy.
      ( IsValue f
      , KnownFields r
      , SubRow r r

--- a/typelet/src/TypeLet/Plugin/NameResolution.hs
+++ b/typelet/src/TypeLet/Plugin/NameResolution.hs
@@ -22,7 +22,7 @@ instance Outputable ResolvedNames where
 
 resolveNames :: TcPluginM 'Init ResolvedNames
 resolveNames = do
-    m <- do r <- findImportedModule typeletMod (Just typeletPkg)
+    m <- do r <- findImportedModule typeletMod (OtherPkg typeletUnitId)
             case r of
               Found _ m  -> return m
               _otherwise -> panic $ "Could not find "
@@ -38,6 +38,5 @@ resolveNames = do
     typeletMod :: ModuleName
     typeletMod = mkModuleName "TypeLet.UserAPI"
 
-    typeletPkg :: FastString
-    typeletPkg = fsLit "typelet"
-
+    typeletUnitId :: UnitId
+    typeletUnitId = stringToUnitId "typelet"

--- a/typelet/typelet.cabal
+++ b/typelet/typelet.cabal
@@ -41,7 +41,7 @@ library
         TypeLet.Plugin.Substitution
     build-depends:
         base >= 4.13 && < 4.17
-      , ghc-tcplugin-api >= 0.7 && < 0.8
+      , ghc-tcplugin-api >= 0.8 && < 0.9
 
         -- whichever versions are bundled with ghc:
       , containers


### PR DESCRIPTION
This adapts `large-anon` to `ghc-9.2` and `ghc-tcplugin-api-0.8.0.0` (still a package candidate on Hackage). However this doesn't work yet, because it requires changes to `record-dot-preprocessor`. This is because `OverloadedRecordDot` is insufficient, as it doesn't provide overloaded record update which we make use of.