### PR TITLE
Wrap field types with parens

### DIFF
--- a/large-records/src/Data/Record/Internal/GHC/Fresh.hs
+++ b/large-records/src/Data/Record/Internal/GHC/Fresh.hs
@@ -39,10 +39,13 @@ instance MonadFresh Fresh where
 
       -- Even when we generate fresh names, ghc can still complain about name
       -- shadowing, because this check only considers the 'OccName', not the
-      -- unique. We therefore prefix the name with an underscore to avoid the
+      -- unique. We therefore prefix the name with an "lr_" to avoid the
       -- warning.
+      --
+      -- Note: we can't just use underscores for prefixes because ghc will
+      -- treat such names as PartialTypeSignatures holes.
       newOccName :: OccName -> OccName
-      newOccName n = mkOccName (occNameSpace n) . ("_" ++) $ occNameString n
+      newOccName n = mkOccName (occNameSpace n) . ("lr_" ++) $ occNameString n
 
 runFresh :: Fresh a -> IORef NameCache -> IO a
 runFresh = runReaderT . unwrapFresh

--- a/large-records/src/Data/Record/Internal/GHC/Fresh.hs
+++ b/large-records/src/Data/Record/Internal/GHC/Fresh.hs
@@ -39,13 +39,10 @@ instance MonadFresh Fresh where
 
       -- Even when we generate fresh names, ghc can still complain about name
       -- shadowing, because this check only considers the 'OccName', not the
-      -- unique. We therefore prefix the name with an "lr_" to avoid the
+      -- unique. We therefore prefix the name with an underscore to avoid the
       -- warning.
-      --
-      -- Note: we can't just use underscores for prefixes because ghc will
-      -- treat such names as PartialTypeSignatures holes.
       newOccName :: OccName -> OccName
-      newOccName n = mkOccName (occNameSpace n) . ("lr_" ++) $ occNameString n
+      newOccName n = mkOccName (occNameSpace n) . ("_" ++) $ occNameString n
 
 runFresh :: Fresh a -> IORef NameCache -> IO a
 runFresh = runReaderT . unwrapFresh

--- a/large-records/src/Data/Record/Internal/GHC/TemplateHaskellStyle.hs
+++ b/large-records/src/Data/Record/Internal/GHC/TemplateHaskellStyle.hs
@@ -38,6 +38,7 @@ module Data.Record.Internal.GHC.TemplateHaskellStyle (
     -- ** Without direct equivalent
   , intE
     -- * Types
+  , parensT
   , litT
   , pattern VarT
   , pattern ConT
@@ -336,6 +337,10 @@ intE = litE . HsInt defExt . mkIntegralLit
 {-------------------------------------------------------------------------------
   Types
 -------------------------------------------------------------------------------}
+
+-- | Equivalent of 'Language.Haskell.TH.Lib.parensT'
+parensT :: LHsType GhcPs -> LHsType GhcPs
+parensT = noLocA . HsParTy defExt
 
 -- | Equivalent of 'Language.Haskell.TH.Lib.litT'
 litT :: HsTyLit -> LHsType GhcPs

--- a/large-records/src/Data/Record/Internal/Plugin/Record.hs
+++ b/large-records/src/Data/Record/Internal/Plugin/Record.hs
@@ -100,7 +100,7 @@ viewField ::
      MonadError Exception m
   => (LRdrName, LHsType GhcPs) -> m (Int -> Field)  
 viewField (name, typ) =
-  return $ Field name (getBangType typ) (getBangStrictness typ)
+  return $ Field name (parensT (getBangType typ)) (getBangStrictness typ)
 
 viewRecordDerivings ::
      MonadError Exception m


### PR DESCRIPTION
```haskell
import Servant.API.Generic
import Servant.API

{-# ANN type X largeRecord #-}
data X mode =
  MkX { f1 :: mode :- Y }
 ```
->
 ```haskell
 data X mode =
   forall a. a ~ mode :- Y =>
     MkX { f1 :: a }
 ```
 
 Which will be parsed (at renaming stage) as
 `forall a. (a ~ mode) :- Y =>`
 not as
 `forall a. a ~ (mode :- Y) =>`
