### PR TITLE
Add explicit 'forall' for unsafe[Get/Set]Index

### DIFF
--- a/large-records/large-records.cabal
+++ b/large-records/large-records.cabal
@@ -101,6 +101,7 @@ test-suite test-large-records
       Test.Record.Sanity.Strictness
       Test.Record.Sanity.StrictnessStrictData
       Test.Record.Sanity.GhcGenerics
+      Test.Record.Sanity.NamedWildCards
       Test.Record.Util
 
   build-depends:

--- a/large-records/test/Test/Record/Sanity/NamedWildCards.hs
+++ b/large-records/test/Test/Record/Sanity/NamedWildCards.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE ConstraintKinds       #-}
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE GADTs                 #-}
+{-# LANGUAGE KindSignatures        #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE TypeOperators         #-}
+{-# LANGUAGE UndecidableInstances  #-}
+{-# LANGUAGE NamedWildCards        #-}
+{-# LANGUAGE PolyKinds             #-}
+
+{-# OPTIONS_GHC -fplugin=Data.Record.Plugin #-}
+
+module Test.Record.Sanity.NamedWildCards () where
+
+{-# ANN type X largeRecord #-}
+data X = MkX {}
+
+{-# ANN type Y largeRecord #-}
+data Y a = MkY {}
+
+{-# ANN type Z largeRecord #-}
+data Z a (b :: a) = MkZ {}


### PR DESCRIPTION
Fix for #121. With enabled NamedWildCards all "_x" names are treated as typed holes.