### PR TITLE
Derive NFData generically

### DIFF
--- a/large-anon/large-anon.cabal
+++ b/large-anon/large-anon.cabal
@@ -71,6 +71,7 @@ library
       base             >= 4.13  && < 4.18
     , aeson            >= 1.4.4 && < 2.2
     , containers       >= 0.6.2 && < 0.7
+    , deepseq          >= 1.4.4 && < 1.5
     , ghc-tcplugin-api >= 0.8   && < 0.9
     , hashable         >= 1.3   && < 1.5
     , mtl              >= 2.2.1 && < 2.3

--- a/large-anon/src/Data/Record/Anon/Internal/Advanced.hs
+++ b/large-anon/src/Data/Record/Anon/Internal/Advanced.hs
@@ -79,6 +79,7 @@ module Data.Record.Anon.Internal.Advanced (
 import Prelude hiding (map, mapM, zip, zipWith, sequenceA, pure)
 import qualified Prelude
 
+import Control.DeepSeq (NFData (..))
 import Data.Aeson (ToJSON(..), FromJSON(..))
 import Data.Bifunctor
 import Data.Coerce (coerce)
@@ -98,9 +99,10 @@ import TypeLet.UserAPI
 
 import qualified Optics.Core as Optics
 
-import qualified Data.Record.Generic.Eq   as Generic
-import qualified Data.Record.Generic.JSON as Generic
-import qualified Data.Record.Generic.Show as Generic
+import qualified Data.Record.Generic.Eq     as Generic
+import qualified Data.Record.Generic.JSON   as Generic
+import qualified Data.Record.Generic.NFData as Generic
+import qualified Data.Record.Generic.Show   as Generic
 
 import Data.Record.Anon.Internal.Core.Canonical (Canonical)
 import Data.Record.Anon.Internal.Core.Diff (Diff)
@@ -554,6 +556,9 @@ instance ( RecordConstraints f r Eq
          , RecordConstraints f r Ord
          ) => Ord (Record f r) where
   compare = Generic.gcompare
+
+instance RecordConstraints f r NFData => NFData (Record f r) where
+  rnf = Generic.grnf
 
 instance RecordConstraints f r ToJSON => ToJSON (Record f r) where
   toJSON = Generic.gtoJSON

--- a/large-anon/src/Data/Record/Anon/Internal/Simple.hs
+++ b/large-anon/src/Data/Record/Anon/Internal/Simple.hs
@@ -64,11 +64,13 @@ module Data.Record.Anon.Internal.Simple (
 
 import Prelude hiding (sequenceA)
 
+import Control.DeepSeq (NFData(..))
 import Data.Aeson (ToJSON(..), FromJSON(..))
 import Data.Bifunctor
 import Data.Record.Generic
 import Data.Record.Generic.Eq
 import Data.Record.Generic.JSON
+import Data.Record.Generic.NFData
 import Data.Record.Generic.Show
 import Data.Tagged
 import GHC.Exts
@@ -254,6 +256,9 @@ instance ( RecordConstraints r Eq
          , RecordConstraints r Ord
          ) => Ord (Record r) where
   compare = gcompare
+
+instance RecordConstraints r NFData => NFData (Record r) where
+  rnf = grnf
 
 instance RecordConstraints r ToJSON => ToJSON (Record r) where
   toJSON = gtoJSON

--- a/large-generics/large-generics.cabal
+++ b/large-generics/large-generics.cabal
@@ -32,6 +32,7 @@ library
       Data.Record.Generic.JSON
       Data.Record.Generic.Lens.VL
       Data.Record.Generic.LowerBound
+      Data.Record.Generic.NFData
       Data.Record.Generic.Show
   default-language:
       Haskell2010
@@ -43,6 +44,7 @@ library
   build-depends:
       base         >= 4.13  && < 4.17
     , aeson        >= 1.4.4 && < 2.2
+    , deepseq      >= 1.4.4 && < 1.5
     , generics-sop >= 0.5   && < 0.6
     , sop-core     >= 0.5   && < 0.6
     , primitive    >= 0.7   && < 0.8

--- a/large-generics/src/Data/Record/Generic/NFData.hs
+++ b/large-generics/src/Data/Record/Generic/NFData.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE TypeApplications #-}
+
+module Data.Record.Generic.NFData (
+    grnf
+  ) where
+
+import Control.DeepSeq (NFData, rnf)
+import Data.Record.Generic
+import qualified Data.Record.Generic.Rep as Rep
+
+-- | Generic rnf function
+--
+-- Typical usage:
+--
+-- > instance NFData T where
+-- >   rnf = grnf
+--
+grnf :: (Generic a, Constraints a NFData) => a -> ()
+grnf =
+    rnf
+  . Rep.collapse
+  . Rep.cmap (Proxy @NFData) (mapIK rnf)
+  . from

--- a/large-records/src/Data/Record/Plugin/Runtime.hs
+++ b/large-records/src/Data/Record/Plugin/Runtime.hs
@@ -36,6 +36,7 @@ module Data.Record.Plugin.Runtime (
   , LR.ThroughLRGenerics(WrapThroughLRGenerics, unwrapThroughLRGenerics)
   , LR.gcompare
   , LR.geq
+  , LR.grnf
   , LR.gshowsPrec
   , LR.noInlineUnsafeCo
     -- * Auxiliary
@@ -56,6 +57,7 @@ import qualified Data.Foldable                    as Foldable
 import qualified Data.Record.Generic              as LR
 import qualified Data.Record.Generic.Eq           as LR
 import qualified Data.Record.Generic.GHC          as LR
+import qualified Data.Record.Generic.NFData       as LR
 import qualified Data.Record.Generic.Rep.Internal as LR
 import qualified Data.Record.Generic.Show         as LR
 import qualified GHC.Records.Compat               as GRC


### PR DESCRIPTION
Fixes #93

Added support to derive `NFData` instances generically:

Sample usage:

```haskell
import Data.Record.Plugin.Runtime (grnf)

instance NFData MyLargeRecord where
  rnf = grnf
```