### PR TITLE
Depend on new releases

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -12,23 +12,6 @@ source-repository-package
   tag: f13fedc299727b2706f26cdfeff3913923cb1a79
   subdir: beam-core beam-migrate beam-sqlite
 
--- TODO: Delete once https://github.com/ndmitchell/record-dot-preprocessor/pull/57 is released
-source-repository-package
-  type: git
-  location: https://github.com/edsko/record-dot-preprocessor
-  tag: cfc5a491ab7c2969994875c557acb2715ee12562
-
--- TODO: Delete once https://github.com/sheaf/ghc-tcplugin-api/pull/6 is released
-source-repository-package
-  type: git
-  location: https://github.com/sheaf/ghc-tcplugin-api
-  tag: 93a28bbe22bd408bc7a2b56a9f17393977989b77 
-
-allow-newer: validation-selective:base
-
--- 2.1.2.0 introduces 'AesonException' which clashes with yaml
-constraints: aeson < 2.1.2.0
-
 -- enable for GHC head
 -- repository head.hackage.ghc.haskell.org
 --    url: https://ghc.gitlab.haskell.org/head.hackage/

--- a/large-records/large-records.cabal
+++ b/large-records/large-records.cabal
@@ -55,8 +55,8 @@ library
       -- transformers 0.5.6 introduces Writer.CPS
     , transformers >= 0.5.6 && < 0.7
 
-      -- TODO: This should be 0.2.16 (after it is released)
-    , record-dot-preprocessor >= 0.2.15 && < 0.3
+      -- 0.2.16 introduces support for ghc 9.4
+    , record-dot-preprocessor >= 0.2.16 && < 0.3
 
       -- whatever versions are bundled with ghc
     , ghc
@@ -115,14 +115,12 @@ test-suite test-large-records
     , large-generics
     , mtl
     , newtype
+    , record-dot-preprocessor
     , record-hasfield
     , tasty
     , tasty-hunit
     , template-haskell
     , transformers
-
-      -- <https://github.com/ndmitchell/record-dot-preprocessor/pull/48>
-    , record-dot-preprocessor >= 0.2.14
   hs-source-dirs:
       test
   default-language:


### PR DESCRIPTION
This removes the temporary overrides in cabal.project.