### PR TITLE
Fix incremental record construction

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.16.3
+# version: 0.16.5
 #
-# REGENDATA ("0.16.3",["github","cabal.project"])
+# REGENDATA ("0.16.5",["github","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -37,14 +37,9 @@ jobs:
             compilerVersion: 9.4.5
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.4.4
+          - compiler: ghc-9.2.8
             compilerKind: ghc
-            compilerVersion: 9.4.4
-            setup-method: ghcup
-            allow-failure: false
-          - compiler: ghc-9.2.7
-            compilerKind: ghc
-            compilerVersion: 9.2.7
+            compilerVersion: 9.2.8
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.0.2
@@ -179,12 +174,12 @@ jobs:
       - name: initial cabal.project for sdist
         run: |
           touch cabal.project
-          if [ $((HCNUMVER < 90405)) -ne 0 ] ; then echo "packages: $GITHUB_WORKSPACE/source/large-generics" >> cabal.project ; fi
-          if [ $((HCNUMVER < 90405)) -ne 0 ] ; then echo "packages: $GITHUB_WORKSPACE/source/large-records" >> cabal.project ; fi
+          echo "packages: $GITHUB_WORKSPACE/source/large-generics" >> cabal.project
+          echo "packages: $GITHUB_WORKSPACE/source/large-records" >> cabal.project
           if [ $((HCNUMVER < 81000)) -ne 0 ] ; then echo "packages: $GITHUB_WORKSPACE/source/large-records-benchmarks" >> cabal.project ; fi
-          if [ $((HCNUMVER < 90400 || HCNUMVER >= 90405)) -ne 0 ] ; then echo "packages: $GITHUB_WORKSPACE/source/large-anon" >> cabal.project ; fi
-          if [ $((HCNUMVER < 90405)) -ne 0 ] ; then echo "packages: $GITHUB_WORKSPACE/source/beam-large-records" >> cabal.project ; fi
-          if [ $((HCNUMVER < 90405)) -ne 0 ] ; then echo "packages: $GITHUB_WORKSPACE/source/typelet" >> cabal.project ; fi
+          echo "packages: $GITHUB_WORKSPACE/source/large-anon" >> cabal.project
+          echo "packages: $GITHUB_WORKSPACE/source/beam-large-records" >> cabal.project
+          echo "packages: $GITHUB_WORKSPACE/source/typelet" >> cabal.project
           cat cabal.project
       - name: sdist
         run: |
@@ -211,24 +206,24 @@ jobs:
           rm -f cabal.project cabal.project.local
           touch cabal.project
           touch cabal.project.local
-          if [ $((HCNUMVER < 90405)) -ne 0 ] ; then echo "packages: ${PKGDIR_large_generics}" >> cabal.project ; fi
-          if [ $((HCNUMVER < 90405)) -ne 0 ] ; then echo "packages: ${PKGDIR_large_records}" >> cabal.project ; fi
+          echo "packages: ${PKGDIR_large_generics}" >> cabal.project
+          echo "packages: ${PKGDIR_large_records}" >> cabal.project
           if [ $((HCNUMVER < 81000)) -ne 0 ] ; then echo "packages: ${PKGDIR_large_records_benchmarks}" >> cabal.project ; fi
-          if [ $((HCNUMVER < 90400 || HCNUMVER >= 90405)) -ne 0 ] ; then echo "packages: ${PKGDIR_large_anon}" >> cabal.project ; fi
-          if [ $((HCNUMVER < 90405)) -ne 0 ] ; then echo "packages: ${PKGDIR_beam_large_records}" >> cabal.project ; fi
-          if [ $((HCNUMVER < 90405)) -ne 0 ] ; then echo "packages: ${PKGDIR_typelet}" >> cabal.project ; fi
-          if [ $((HCNUMVER < 90405)) -ne 0 ] ; then echo "package large-generics" >> cabal.project ; fi
-          if [ $((HCNUMVER < 90405)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
-          if [ $((HCNUMVER < 90405)) -ne 0 ] ; then echo "package large-records" >> cabal.project ; fi
-          if [ $((HCNUMVER < 90405)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
+          echo "packages: ${PKGDIR_large_anon}" >> cabal.project
+          echo "packages: ${PKGDIR_beam_large_records}" >> cabal.project
+          echo "packages: ${PKGDIR_typelet}" >> cabal.project
+          echo "package large-generics" >> cabal.project
+          echo "    ghc-options: -Werror=missing-methods" >> cabal.project
+          echo "package large-records" >> cabal.project
+          echo "    ghc-options: -Werror=missing-methods" >> cabal.project
           if [ $((HCNUMVER < 81000)) -ne 0 ] ; then echo "package large-records-benchmarks" >> cabal.project ; fi
           if [ $((HCNUMVER < 81000)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
-          if [ $((HCNUMVER < 90400 || HCNUMVER >= 90405)) -ne 0 ] ; then echo "package large-anon" >> cabal.project ; fi
-          if [ $((HCNUMVER < 90400 || HCNUMVER >= 90405)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
-          if [ $((HCNUMVER < 90405)) -ne 0 ] ; then echo "package beam-large-records" >> cabal.project ; fi
-          if [ $((HCNUMVER < 90405)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
-          if [ $((HCNUMVER < 90405)) -ne 0 ] ; then echo "package typelet" >> cabal.project ; fi
-          if [ $((HCNUMVER < 90405)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
+          echo "package large-anon" >> cabal.project
+          echo "    ghc-options: -Werror=missing-methods" >> cabal.project
+          echo "package beam-large-records" >> cabal.project
+          echo "    ghc-options: -Werror=missing-methods" >> cabal.project
+          echo "package typelet" >> cabal.project
+          echo "    ghc-options: -Werror=missing-methods" >> cabal.project
           cat >> cabal.project <<EOF
           source-repository-package
             type:     git

--- a/beam-large-records/beam-large-records.cabal
+++ b/beam-large-records/beam-large-records.cabal
@@ -11,7 +11,7 @@ author:             Edsko de Vries
 maintainer:         edsko@well-typed.com
 category:           Database
 extra-source-files: CHANGELOG.md
-tested-with:        GHC ==8.8.4 || ==8.10.7 || ==9.0.2 || ==9.2.7 || ==9.4.4
+tested-with:        GHC ==8.8.4 || ==8.10.7 || ==9.0.2 || ==9.2.8 || ==9.4.5
 
 source-repository head
   type:     git

--- a/large-anon/CHANGELOG.md
+++ b/large-anon/CHANGELOG.md
@@ -1,6 +1,24 @@
 # Revision history for large-anon
 
-## 0.2.1 -- 2023-07-05
+## 0.3 -- 2023-07-04
+
+* Critical bugfix (#146): incremental record construction was fundamentally
+  broken. This is a major version dump because the internal representation
+  is different, so if any code happens to rely on that, it will need to be
+  updated. Specifically, indices into the underlying representation of the
+  record are now interpreted from the _end_ of the array, rather than the
+  start; this is necessary to ensure that inserting new fields (which are
+  prepended to the record row) do not affect the indices of old fields.
+  With thanks to Johannes Gerer for the bug report and initial investigation.
+* One somewhat unfortunate consequence of this new design is that we can no
+  longer resolve constraints `HasField` constraints unless _all_ fields in the
+  record are known. Previously, we had limited support for resolving `HasField`
+  constraints for rows such as `(a := Int ': r)`. However, since this
+  support did not extend to other constraints, it was probably not very useful
+  anyway; `large-anon` is quite explicit about not supporting inductive
+  reasoning.
+
+## 0.2.1 -- 2023-06-05
 
 * Add `distribute` (Johannes Gerer, #142)
 

--- a/large-anon/large-anon.cabal
+++ b/large-anon/large-anon.cabal
@@ -127,6 +127,7 @@ test-suite test-large-anon
       Test.Infra.MarkStrictness
       Test.Prop.Record.Combinators.Constrained
       Test.Prop.Record.Combinators.Simple
+      Test.Prop.Record.Diff
       Test.Prop.Record.Model
       Test.Prop.Record.Model.Generator
       Test.Prop.Record.Model.Orphans
@@ -161,6 +162,7 @@ test-suite test-large-anon
     , arrows
     , base
     , bytestring
+    , containers
     , large-anon
     , large-generics
     , mtl

--- a/large-anon/large-anon.cabal
+++ b/large-anon/large-anon.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               large-anon
-version:            0.2.1
+version:            0.3.0
 synopsis:           Scalable anonymous records
 description:        The @large-anon@ package provides support for anonymous
                     records in Haskell, with a focus on compile-time (and
@@ -12,7 +12,7 @@ maintainer:         edsko@well-typed.com
 category:           Records
 extra-source-files: CHANGELOG.md
                     test/Test/Sanity/RebindableSyntax/Tests.hs
-tested-with:        GHC ==8.8.4 || ==8.10.7 || ==9.0.2 || ==9.2.7 || ==9.4.5
+tested-with:        GHC ==8.8.4 || ==8.10.7 || ==9.0.2 || ==9.2.8 || ==9.4.5
 
 library
   exposed-modules:

--- a/large-anon/large-anon.cabal
+++ b/large-anon/large-anon.cabal
@@ -150,6 +150,7 @@ test-suite test-large-anon
       Test.Sanity.RebindableSyntax.Disabled
       Test.Sanity.RebindableSyntax.Enabled
       Test.Sanity.RecordLens
+      Test.Sanity.Regression
       Test.Sanity.Simple
       Test.Sanity.SrcPlugin.WithoutTypelet
       Test.Sanity.SrcPlugin.WithTypelet

--- a/large-anon/src/Data/Record/Anon/Advanced.hs
+++ b/large-anon/src/Data/Record/Anon/Advanced.hs
@@ -332,8 +332,7 @@ lens = A.lens
 -- :}
 --
 -- 'HasField' constraints can be resolved for merged records, subject to the
--- same condition discussed in 'get': all fields in the record must be known up
--- to the requested field (in case of shadowing). So the record /may/ be fully
+-- same condition discussed in 'get': all fields in the record must be fully
 -- known:
 --
 -- >>> :{
@@ -341,15 +340,7 @@ lens = A.lens
 -- example r = get #b r
 -- :}
 --
--- but it doesn't have to be:
---
--- >>> :{
--- example :: Record I (Merge '[ "a" := Bool ] r) -> I Bool
--- example = get #a
--- :}
---
--- However, just like in the case of unknown fields (see example in 'get'),
--- if earlier parts in the record are unknown we get type error:
+-- If parts in the record are unknown we get type error:
 --
 -- >>> :{
 -- example :: Record I (Merge r '[ "b" := Char ]) -> I Char

--- a/large-anon/src/Data/Record/Anon/Internal/Advanced.hs
+++ b/large-anon/src/Data/Record/Anon/Internal/Advanced.hs
@@ -164,6 +164,10 @@ unsafeFromCanonical = NoPending
 data Field n where
   Field :: (KnownSymbol n, KnownHash n) => Proxy n -> Field n
 
+-- | 'Show' instance relies on the 'IsLabel' instance
+instance Show (Field n) where
+  show (Field p) = "#" ++ symbolVal p
+
 instance (n ~ n', KnownSymbol n, KnownHash n) => IsLabel n' (Field n) where
   fromLabel = Field (Proxy @n)
 

--- a/large-anon/src/Data/Record/Anon/Internal/Advanced.hs
+++ b/large-anon/src/Data/Record/Anon/Internal/Advanced.hs
@@ -111,7 +111,6 @@ import Data.Record.Anon.Internal.Core.Canonical (Canonical)
 import Data.Record.Anon.Internal.Core.Diff (Diff)
 import Data.Record.Anon.Internal.Core.FieldName
 import Data.Record.Anon.Internal.Reflection (Reflected(..))
-import Data.Record.Anon.Internal.Util.StrictArray (StrictArray)
 
 import Data.Record.Anon.Plugin.Internal.Runtime
 
@@ -446,9 +445,9 @@ reifySubRow =
   where
     ixs :: Record (K Int) r'
     ixs = unsafeFromCanonical $
-            Canon.fromVector $ co $ proxy projectIndices (Proxy @'(r, r'))
+            Canon.fromList $ co $ proxy projectIndices (Proxy @'(r, r'))
 
-    co :: StrictArray Int -> StrictArray (K Int Any)
+    co :: [Int] -> [K Int Any]
     co = coerce
 
     aux :: forall x. K Int x -> K String x -> InRow r x
@@ -461,7 +460,7 @@ reflectSubRow :: forall k (r :: Row k) (r' :: Row k).
   -> Reflected (SubRow r r')
 reflectSubRow (toCanonical -> ixs) =
     Unsafe.reflectSubRow $ Tagged $
-      (\inRow@(InRow p) -> aux inRow p) <$> Canon.toVector ixs
+      (\inRow@(InRow p) -> aux inRow p) <$> Canon.toList ixs
   where
     aux :: forall x n. RowHasField n r x => InRow r x -> Proxy n -> Int
     aux _ _ = proxy rowHasField (Proxy @'(n, r, x))

--- a/large-anon/src/Data/Record/Anon/Internal/Core/Canonical.hs
+++ b/large-anon/src/Data/Record/Anon/Internal/Core/Canonical.hs
@@ -46,7 +46,7 @@ module Data.Record.Anon.Internal.Core.Canonical (
 #endif
   ) where
 
-import Prelude hiding (map, mapM, zip, zipWith, sequenceA, pure)
+import Prelude hiding (map, mapM, zipWith, sequenceA, pure)
 
 import Data.Coerce (coerce)
 import Data.Kind
@@ -164,12 +164,12 @@ insert new = prepend
 -- order of the new record.
 --
 -- @O(n)@ (in both directions)
-lens :: StrictArray Int -> Canonical f -> (Canonical f, Canonical f -> Canonical f)
+lens :: [Int] -> Canonical f -> (Canonical f, Canonical f -> Canonical f)
 lens is (Canonical v) = (
       Canonical $
         Strict.backpermute v is
     , \(Canonical v') -> Canonical $
-         Strict.update v (Strict.zipWith (,) is v')
+         Strict.update v (zip is $ Foldable.toList v')
     )
 
 {-------------------------------------------------------------------------------

--- a/large-anon/src/Data/Record/Anon/Internal/Core/Diff.hs
+++ b/large-anon/src/Data/Record/Anon/Internal/Core/Diff.hs
@@ -75,7 +75,10 @@ import qualified Data.Record.Anon.Internal.Util.SmallHashMap as HashMap
 data Diff (f :: k -> Type) = Diff {
       -- | New values of existing fields
       --
-      -- Indices refer to the original record.
+      -- Indices refer to the /canonical/ record. Since new fields are inserted
+      -- /after/ old fields, field indices do not change as we insert new
+      -- fields. This is key to the soundness of having a 'Canonical' and 'Diff'
+      -- pair.
       diffUpd :: !(IntMap (f Any))
 
       -- | List of new fields, most recently inserted first
@@ -98,7 +101,8 @@ deriving instance Show a => Show (Diff (K a))
 {-------------------------------------------------------------------------------
   Incremental construction
 
-  TODO: We should property check these postconditions.
+  The post-conditions are verified (albeit somewhat implicitly) in
+  "Test.Prop.Record.Diff".
 -------------------------------------------------------------------------------}
 
 -- | Empty difference

--- a/large-anon/src/Data/Record/Anon/Internal/Core/Diff.hs
+++ b/large-anon/src/Data/Record/Anon/Internal/Core/Diff.hs
@@ -42,7 +42,7 @@ import Data.Record.Generic.Rep.Internal (noInlineUnsafeCo)
 
 import qualified Data.List.NonEmpty as NE
 
-import Data.Record.Anon.Internal.Core.Canonical (Canonical(..))
+import Data.Record.Anon.Internal.Core.Canonical (Canonical)
 import Data.Record.Anon.Internal.Core.FieldName (FieldName)
 import Data.Record.Anon.Internal.Util.SmallHashMap (SmallHashMap)
 

--- a/large-anon/src/Data/Record/Anon/Internal/Plugin/TC/Constraints/KnownFields.hs
+++ b/large-anon/src/Data/Record/Anon/Internal/Plugin/TC/Constraints/KnownFields.hs
@@ -11,11 +11,11 @@ module Data.Record.Anon.Internal.Plugin.TC.Constraints.KnownFields (
 
 import Data.Void
 
-import Data.Record.Anon.Internal.Plugin.TC.Row.KnownRow (KnownRow)
-import Data.Record.Anon.Internal.Plugin.TC.Row.ParsedRow (Fields)
 import Data.Record.Anon.Internal.Plugin.TC.GhcTcPluginAPI
 import Data.Record.Anon.Internal.Plugin.TC.NameResolution
 import Data.Record.Anon.Internal.Plugin.TC.Parsing
+import Data.Record.Anon.Internal.Plugin.TC.Row.KnownRow (KnownRow)
+import Data.Record.Anon.Internal.Plugin.TC.Row.ParsedRow (Fields)
 import Data.Record.Anon.Internal.Plugin.TC.TyConSubst
 
 import qualified Data.Record.Anon.Internal.Plugin.TC.Row.KnownField as KnownField
@@ -85,7 +85,7 @@ evidenceKnownFields ::
   -> KnownRow a
   -> TcPluginM 'Solve EvTerm
 evidenceKnownFields ResolvedNames{..} CKnownFields{..} r = do
-    fields <- mapM KnownField.toExpr (KnownRow.toList r)
+    fields <- mapM KnownField.toExpr (KnownRow.inRowOrder r)
     return $
       evDataConApp
         (classDataCon clsKnownFields)

--- a/large-anon/src/Data/Record/Anon/Internal/Plugin/TC/Constraints/RowHasField.hs
+++ b/large-anon/src/Data/Record/Anon/Internal/Plugin/TC/Constraints/RowHasField.hs
@@ -11,10 +11,11 @@ module Data.Record.Anon.Internal.Plugin.TC.Constraints.RowHasField (
 import Data.Void
 import GHC.Stack
 
-import Data.Record.Anon.Internal.Plugin.TC.Row.ParsedRow (Fields, FieldLabel(..))
 import Data.Record.Anon.Internal.Plugin.TC.GhcTcPluginAPI
 import Data.Record.Anon.Internal.Plugin.TC.NameResolution
 import Data.Record.Anon.Internal.Plugin.TC.Parsing
+import Data.Record.Anon.Internal.Plugin.TC.Row.KnownRow (KnownRowField(..))
+import Data.Record.Anon.Internal.Plugin.TC.Row.ParsedRow (Fields, FieldLabel(..))
 import Data.Record.Anon.Internal.Plugin.TC.TyConSubst
 
 import qualified Data.Record.Anon.Internal.Plugin.TC.Row.KnownRow  as KnownRow
@@ -143,10 +144,10 @@ solveRowHasField rn orig (L loc hf@CRowHasField{hasFieldLabel = FieldKnown name,
             -- TODO: We should issue an error here rather than leaving the
             -- constraint unsolved: we /know/ the field does not exist
             return (Nothing, [])
-          Just (i, typ) -> do
+          Just info -> do
             eq <- newWanted loc $
                     mkPrimEqPredRole Nominal
                       hasFieldTypeField
-                      typ
-            ev <- evidenceHasField rn hf i
+                      (knownRowFieldInfo info)
+            ev <- evidenceHasField rn hf (knownRowFieldIndex info)
             return (Just (ev, orig), [mkNonCanonical eq])

--- a/large-anon/src/Data/Record/Anon/Internal/Plugin/TC/Constraints/RowHasField.hs
+++ b/large-anon/src/Data/Record/Anon/Internal/Plugin/TC/Constraints/RowHasField.hs
@@ -17,6 +17,7 @@ import Data.Record.Anon.Internal.Plugin.TC.NameResolution
 import Data.Record.Anon.Internal.Plugin.TC.Parsing
 import Data.Record.Anon.Internal.Plugin.TC.TyConSubst
 
+import qualified Data.Record.Anon.Internal.Plugin.TC.Row.KnownRow  as KnownRow
 import qualified Data.Record.Anon.Internal.Plugin.TC.Row.ParsedRow as ParsedRow
 
 {-------------------------------------------------------------------------------
@@ -132,15 +133,20 @@ solveRowHasField ::
 solveRowHasField _ _ (L _ CRowHasField{hasFieldLabel = FieldVar _}) =
     return (Nothing, [])
 solveRowHasField rn orig (L loc hf@CRowHasField{hasFieldLabel = FieldKnown name, ..}) =
-    case ParsedRow.lookup name hasFieldRecord of
+    case ParsedRow.allKnown hasFieldRecord of
       Nothing ->
-        -- TODO: If the record is fully known, we should issue a custom type
-        -- error here rather than leaving the constraint unsolved
+        -- Not all fields are known; leave the constraint unsolved
         return (Nothing, [])
-      Just (i, typ) -> do
-        eq <- newWanted loc $
-                mkPrimEqPredRole Nominal
-                  hasFieldTypeField
-                  typ
-        ev <- evidenceHasField rn hf i
-        return (Just (ev, orig), [mkNonCanonical eq])
+      Just allKnown ->
+        case KnownRow.lookup name allKnown of
+          Nothing ->
+            -- TODO: We should issue an error here rather than leaving the
+            -- constraint unsolved: we /know/ the field does not exist
+            return (Nothing, [])
+          Just (i, typ) -> do
+            eq <- newWanted loc $
+                    mkPrimEqPredRole Nominal
+                      hasFieldTypeField
+                      typ
+            ev <- evidenceHasField rn hf i
+            return (Just (ev, orig), [mkNonCanonical eq])

--- a/large-anon/src/Data/Record/Anon/Internal/Plugin/TC/Rewriter.hs
+++ b/large-anon/src/Data/Record/Anon/Internal/Plugin/TC/Rewriter.hs
@@ -100,4 +100,4 @@ computeMetadataOf :: Maybe Type -> KnownRow Type -> TcType
 computeMetadataOf mf r =
     mkPromotedListTy
       (mkTupleTy Boxed [mkTyConTy typeSymbolKindCon, liftedTypeKind])
-      (map (KnownField.toType mf) $ KnownRow.toList r)
+      (map (KnownField.toType mf) $ KnownRow.inRowOrder r)

--- a/large-anon/src/Data/Record/Anon/Internal/Plugin/TC/Row/KnownRow.hs
+++ b/large-anon/src/Data/Record/Anon/Internal/Plugin/TC/Row/KnownRow.hs
@@ -18,6 +18,8 @@ module Data.Record.Anon.Internal.Plugin.TC.Row.KnownRow (
   , fromList
   , toList
   , visibleMap
+    -- * Query
+  , lookup
     -- * Combinators
   , traverse
   , indexed
@@ -26,7 +28,7 @@ module Data.Record.Anon.Internal.Plugin.TC.Row.KnownRow (
   , isSubRow
   ) where
 
-import Prelude hiding (traverse)
+import Prelude hiding (traverse, lookup)
 import qualified Prelude
 
 import Control.Monad.State (State, evalState, state)
@@ -121,6 +123,17 @@ fromList = go [] 0 HashMap.empty True
                  fs
           where
             name = knownFieldName f
+
+{-------------------------------------------------------------------------------
+  Query
+-------------------------------------------------------------------------------}
+
+lookup :: FieldName -> KnownRow Type -> Maybe (Int, Type)
+lookup field KnownRow{..} =
+    aux <$> HashMap.lookup field knownRecordVisible
+  where
+    aux :: Int -> (Int, Type)
+    aux i = (i, knownFieldInfo (knownRecordVector !! i))
 
 {-------------------------------------------------------------------------------
   Combinators

--- a/large-anon/src/Data/Record/Anon/Internal/Plugin/TC/Row/KnownRow.hs
+++ b/large-anon/src/Data/Record/Anon/Internal/Plugin/TC/Row/KnownRow.hs
@@ -14,25 +14,33 @@
 module Data.Record.Anon.Internal.Plugin.TC.Row.KnownRow (
     -- * Definition
     KnownRow(..)
-    -- * Construction
+    -- * Fields
+  , KnownRowField(..)
+  , FieldIndex
+  , toKnownRowField
+  , fromKnownRowField
+    -- * Conversion
   , fromList
-  , toList
+  , inRowOrder
+  , inFieldOrder
   , visibleMap
     -- * Query
   , lookup
     -- * Combinators
   , traverse
-  , indexed
     -- * Check for subrows
   , NotSubRow(..)
-  , isSubRow
+  , Source(..)
+  , Target(..)
+  , isSubRowOf
   ) where
 
 import Prelude hiding (traverse, lookup)
 import qualified Prelude
 
-import Control.Monad.State (State, evalState, state)
 import Data.Either (partitionEithers)
+import Data.List (sortBy)
+import Data.Ord (comparing)
 
 import Data.Record.Anon.Internal.Core.FieldName (FieldName)
 import Data.Record.Anon.Internal.Util.SmallHashMap (SmallHashMap)
@@ -54,7 +62,7 @@ data KnownRow a = KnownRow {
       -- order are not considered equal by the library (merely isomorphic).
       --
       -- May contain duplicates (if fields are shadowed).
-      knownRecordVector :: [KnownField a]
+      knownRecordVector :: [KnownRowField a]
 
       -- | "Most recent" position of each field in the record
       --
@@ -71,16 +79,57 @@ data KnownRow a = KnownRow {
       -- 'False' if some fields are shadowed.
     , knownRecordAllVisible :: Bool
     }
-  deriving (Functor, Foldable)
+  deriving (Functor)
+
+{-------------------------------------------------------------------------------
+  Individual fields
+-------------------------------------------------------------------------------}
+
+-- | Field in a known row
+data KnownRowField a = KnownRowField {
+      knownRowFieldName  :: FieldName
+    , knownRowFieldIndex :: FieldIndex
+    , knownRowFieldInfo  :: a
+    }
+  deriving (Functor)
+
+type FieldIndex = Int
+
+-- | Drop index information
+fromKnownRowField :: KnownRowField a -> KnownField a
+fromKnownRowField field = KnownField {
+      knownFieldName = knownRowFieldName field
+    , knownFieldInfo = knownRowFieldInfo field
+    }
+
+-- | Add index information
+toKnownRowField :: KnownField a -> FieldIndex -> KnownRowField a
+toKnownRowField field ix = KnownRowField {
+      knownRowFieldName  = knownFieldName field
+    , knownRowFieldInfo  = knownFieldInfo field
+    , knownRowFieldIndex = ix
+    }
 
 {-------------------------------------------------------------------------------
   Conversion
 -------------------------------------------------------------------------------}
 
-toList :: KnownRow a -> [KnownField a]
-toList = knownRecordVector
+-- | List of all fields, in row order
+--
+-- This may /NOT/ be the order in which the fields are stored.
+inRowOrder :: KnownRow a -> [KnownField a]
+inRowOrder =
+      map fromKnownRowField
+    . knownRecordVector
 
-visibleMap :: KnownRow a -> SmallHashMap FieldName (KnownField a)
+-- | List of all fields, ordered by fieldIndex
+inFieldOrder :: KnownRow a -> [KnownField a]
+inFieldOrder =
+      map fromKnownRowField
+    . sortBy (comparing knownRowFieldIndex)
+    . knownRecordVector
+
+visibleMap :: KnownRow a -> SmallHashMap FieldName (KnownRowField a)
 visibleMap KnownRow{..} = (knownRecordVector !!) <$> knownRecordVisible
 
 {-------------------------------------------------------------------------------
@@ -88,18 +137,18 @@ visibleMap KnownRow{..} = (knownRecordVector !!) <$> knownRecordVisible
 -------------------------------------------------------------------------------}
 
 fromList :: forall a.
-     [KnownField a]
+     [KnownRowField a]
      -- ^ Fields of the record in the order they appear in the row types
      --
      -- In other words, fields earlier in the list shadow later fields.
   -> KnownRow a
 fromList = go [] 0 HashMap.empty True
   where
-    go :: [KnownField a]  -- Acc fields, reverse order (includes shadowed)
-       -> Int             -- Next index
-       -> SmallHashMap FieldName Int -- Acc indices of visible fields
-       -> Bool            -- Are all already processed fields visible?
-       -> [KnownField a]  -- To process
+    go :: [KnownRowField a]           -- Acc fields, rev order (incl shadowed)
+       -> Int                         -- Next index
+       -> SmallHashMap FieldName Int  -- Acc indices of visible fields
+       -> Bool                        -- All already processed fields visible?
+       -> [KnownRowField a]           -- To process
        -> KnownRow a
     go accFields !nextIndex !accVisible !accAllVisible = \case
         [] -> KnownRow {
@@ -122,18 +171,16 @@ fromList = go [] 0 HashMap.empty True
                  accAllVisible
                  fs
           where
-            name = knownFieldName f
+            name = knownRowFieldName f
 
 {-------------------------------------------------------------------------------
   Query
 -------------------------------------------------------------------------------}
 
-lookup :: FieldName -> KnownRow Type -> Maybe (Int, Type)
+lookup :: FieldName -> KnownRow a -> Maybe (KnownRowField a)
 lookup field KnownRow{..} =
-    aux <$> HashMap.lookup field knownRecordVisible
-  where
-    aux :: Int -> (Int, Type)
-    aux i = (i, knownFieldInfo (knownRecordVector !! i))
+    (knownRecordVector !!) <$>
+      HashMap.lookup field knownRecordVisible
 
 {-------------------------------------------------------------------------------
   Combinators
@@ -142,28 +189,20 @@ lookup field KnownRow{..} =
 traverse :: forall m a b.
      Applicative m
   => KnownRow a
-  -> (FieldName -> a -> m b)
+  -> (FieldName -> FieldIndex -> a -> m b)
   -> m (KnownRow b)
 traverse KnownRow{..} f =
     mkRow <$> Prelude.traverse f' knownRecordVector
   where
-    mkRow :: [KnownField b] -> KnownRow b
+    mkRow :: [KnownRowField b] -> KnownRow b
     mkRow updated = KnownRow {
           knownRecordVector     = updated
         , knownRecordVisible    = knownRecordVisible
         , knownRecordAllVisible = knownRecordAllVisible
         }
 
-    f' :: KnownField a -> m (KnownField b)
-    f' (KnownField nm info) = KnownField nm <$> f nm info
-
-indexed :: KnownRow a -> KnownRow (Int, a)
-indexed r =
-    flip evalState 0 $
-      traverse r (const aux)
-  where
-    aux :: a -> State Int (Int, a)
-    aux a = state $ \i -> ((i, a), succ i)
+    f' :: KnownRowField a -> m (KnownRowField b)
+    f' (KnownRowField nm ix info) = KnownRowField nm ix <$> f nm ix info
 
 {-------------------------------------------------------------------------------
   Check for projections
@@ -171,7 +210,7 @@ indexed r =
 
 -- | Reason why we cannot failed to prove 'SubRow'
 data NotSubRow =
-    -- | We do not support precords with shadowed fields
+    -- | We do not support records with shadowed fields
     --
     -- Since these fields can only come from the source record, and shadowed
     -- fields in the source record are invisible, shadowed fields in the target
@@ -185,40 +224,46 @@ data NotSubRow =
   | SourceMissesFields [FieldName]
   deriving (Show, Eq)
 
+newtype Source a = Source { getSource :: a } deriving (Show, Functor)
+newtype Target a = Target { getTarget :: a } deriving (Show, Functor)
+
 -- | Check if one row is a subrow of another
 --
--- If it is, returns the paired information from both records in the order of
--- the /target/ record along with the index into the /source/ record.
+-- If it is, returns the paired information from both records. If @a@ is a
+-- subrow of @b@, then we can project from @b@ to @a@; for improved clarity,
+-- we therefore mark @a@ as the /target/ and @b@ as the source.
+--
+-- Results are returned in row order of the target.
 --
 -- See 'NotSubRow' for some discussion of shadowing.
-isSubRow :: forall a b.
-     KnownRow a
-  -> KnownRow b
-  -> Either NotSubRow [(Int, (a, b))]
-isSubRow recordA recordB =
-    if not (knownRecordAllVisible recordB) then
+isSubRowOf :: forall a b.
+     KnownRow a  -- ^ Target
+  -> KnownRow b  -- ^ Source
+  -> Either NotSubRow [(Target (KnownField a), Source (KnownRowField b))]
+target `isSubRowOf` source =
+    if not (knownRecordAllVisible target) then
       Left TargetContainsShadowedFields
     else
         uncurry checkMissing
       . partitionEithers
-      $ map findInA (toList recordB)
+        -- It doesn't matter which order we process 'target' in:
+      $ map findInSrc (inRowOrder target)
   where
-    findInA :: KnownField b -> Either FieldName (Int, (a, b))
-    findInA b =
-        case HashMap.lookup (knownFieldName b) (visibleMap (indexed recordA)) of
-          Nothing -> Left  $ knownFieldName b
-          Just a  -> Right $ distrib (knownFieldInfo a, knownFieldInfo b)
+    findInSrc ::
+         KnownField a
+      -> Either FieldName (Target (KnownField a), Source (KnownRowField b))
+    findInSrc a =
+        case HashMap.lookup (knownFieldName a) (visibleMap source) of
+          Nothing -> Left  $ knownFieldName a
+          Just b  -> Right $ (Target a, Source b)
 
     checkMissing :: [FieldName] -> x -> Either NotSubRow x
     checkMissing []      x = Right x
     checkMissing missing _ = Left $ SourceMissesFields missing
-
-    distrib :: ((i, a), b) -> (i, (a, b))
-    distrib ((i, a), b) = (i, (a, b))
 
 {-------------------------------------------------------------------------------
   Outputable
 -------------------------------------------------------------------------------}
 
 instance Outputable a => Outputable (KnownRow a) where
-  ppr = ppr . toList
+  ppr = ppr . inRowOrder

--- a/large-anon/src/Data/Record/Anon/Internal/Plugin/TC/Row/ParsedRow.hs
+++ b/large-anon/src/Data/Record/Anon/Internal/Plugin/TC/Row/ParsedRow.hs
@@ -89,14 +89,14 @@ allKnown =
     postprocess :: [KnownField Type] -> KnownRow Type
     postprocess fields =
           KnownRow.fromList
-        . flip evalState 0
+        . flip evalState (length fields)
         . mapM assignIndex
         $ fields
       where
         assignIndex :: KnownField Type -> State Int (KnownRowField Type)
         assignIndex field = state $ \ix -> (
-              KnownRow.toKnownRowField field ix
-            , succ ix
+              KnownRow.toKnownRowField field (ix - 1)
+            , pred ix
             )
 
 {-------------------------------------------------------------------------------

--- a/large-anon/src/Data/Record/Anon/Internal/Util/StrictArray.hs
+++ b/large-anon/src/Data/Record/Anon/Internal/Util/StrictArray.hs
@@ -9,6 +9,7 @@ module Data.Record.Anon.Internal.Util.StrictArray (
     -- * Array index
   , ArrayIndex(..)
   , ZeroBasedIndex(..)
+  , ReverseIndex(..)
     -- * Reads
   , (!)
     -- * Conversion
@@ -81,6 +82,14 @@ newtype ZeroBasedIndex = ZeroBasedIndex { getZeroBasedIndex :: Int }
 
 instance ArrayIndex ZeroBasedIndex where
   arrayIndex _size = getZeroBasedIndex
+
+-- | Index from the /end/ of the array
+--
+-- @ReverseIndex 0@ points to the final element.
+newtype ReverseIndex = ReverseIndex { getReverseIndex :: Int }
+
+instance ArrayIndex ReverseIndex where
+  arrayIndex size i = size - 1 - getReverseIndex i
 
 {-------------------------------------------------------------------------------
   Reads

--- a/large-anon/src/Data/Record/Anon/Plugin/Internal/Runtime.hs
+++ b/large-anon/src/Data/Record/Anon/Plugin/Internal/Runtime.hs
@@ -58,10 +58,6 @@ import GHC.Exts (Any)
 import GHC.TypeLits
 import Unsafe.Coerce (unsafeCoerce)
 
-import Data.Record.Anon.Internal.Util.StrictArray (StrictArray)
-
-import qualified Data.Record.Anon.Internal.Util.StrictArray as Strict
-
 {-------------------------------------------------------------------------------
   IMPLEMENTATION NOTE
 
@@ -262,10 +258,10 @@ class SubRow (r :: Row k) (r' :: Row k) where
 
 -- | In order of the fields in the /target/ record, the index in the /source/
 type DictSubRow k (r :: Row k) (r' :: Row k) =
-       Tagged '(r, r') (StrictArray Int)
+       Tagged '(r, r') [Int]
 
 evidenceSubRow :: forall k r r'. [Int] -> DictSubRow k r r'
-evidenceSubRow = Tagged . Strict.fromList
+evidenceSubRow = Tagged
 
 {-------------------------------------------------------------------------------
   Utility

--- a/large-anon/test/Test/Prop/Record/Diff.hs
+++ b/large-anon/test/Test/Prop/Record/Diff.hs
@@ -1,0 +1,268 @@
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE EmptyCase           #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE FlexibleInstances   #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE KindSignatures      #-}
+{-# LANGUAGE OverloadedLabels    #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving  #-}
+{-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE TypeOperators       #-}
+
+{-# OPTIONS_GHC -fplugin=Data.Record.Anon.Plugin #-}
+
+module Test.Prop.Record.Diff (tests) where
+
+import Data.Kind
+import Data.Map (Map)
+import Data.SOP
+import Data.Type.Equality
+import GHC.TypeLits
+import Test.QuickCheck
+import Test.Tasty hiding (after)
+import Test.Tasty.QuickCheck
+
+import qualified Data.Map as Map
+
+import Data.Record.Anon
+import Data.Record.Anon.Advanced (Record)
+import qualified Data.Record.Anon.Advanced as Anon
+
+{-------------------------------------------------------------------------------
+  Abstraction over the 'Diff' operations
+-------------------------------------------------------------------------------}
+
+data Op :: Row Type -> Row Type -> Type where
+  -- | Insert new field into the record
+  Insert :: KnownSymbol n => Field n -> Int -> Op r (n := Int : r)
+
+  -- | Get field from the record and check that it has the correct value
+  --
+  -- (The test itself will have to keep track of what the correct value /is/)
+  Get :: (KnownSymbol n, RowHasField n r Int) => Field n -> Op r r
+
+  -- | Update value of a field in the record
+  Set :: (KnownSymbol n, RowHasField n r Int) => Field n -> Int -> Op r r
+
+  -- | Apply all pending changes
+  Apply  :: Op r r
+
+deriving instance Show (Op r r')
+
+data Ops :: Row Type -> Row Type -> Type where
+  Done :: Ops r r
+  Op   :: IsKnownRow r' => Op r r' -> Ops r' r'' -> Ops r r''
+
+
+data TestResult = TestOk | TestFailed String
+  deriving (Show, Eq)
+
+-- | Model to test the actual record against
+type RecordModel = Map String Int
+
+execute :: Ops '[] r -> TestResult
+execute = go Anon.empty Map.empty
+  where
+    go :: Record I r -> RecordModel -> Ops r r' -> TestResult
+    go _ _ Done      = TestOk
+    go r m (Op o os) =
+        case o of
+          Insert f v ->
+            go (Anon.insert f (I v) r) (Map.insert (symbolVal f) v m) os
+          Get f ->
+            case Map.lookup (symbolVal f) m of
+              Nothing ->
+                TestFailed "Unknown field (this indicates a bug in the tests"
+              Just expected ->
+                let actual = unI (Anon.get f r) in
+                if actual == expected
+                  then go r m os
+                  else TestFailed $ concat [
+                      "Expected " ++ show expected
+                    , ", got " ++ show actual
+                    ]
+          Set f v ->
+            go (Anon.set f (I v) r) (Map.insert (symbolVal f) v m) os
+          Apply ->
+            go (Anon.applyPending r) m os
+
+{-------------------------------------------------------------------------------
+  Existential wrappers
+-------------------------------------------------------------------------------}
+
+data SomeField r where
+  SomeField :: (KnownSymbol n, RowHasField n r Int) => Field n -> SomeField r
+
+data SomeOp r where
+  SomeOp :: forall r r'. IsKnownRow r' => Op r r' -> SomeOp r
+
+data SomeOps r where
+  SomeOps :: forall r r'. IsKnownRow r' => Ops r r' -> SomeOps r
+
+{-------------------------------------------------------------------------------
+  Show instances
+
+  These are not lawful (they are not valid Haskell), but try to present
+  readable counter-examples.
+-------------------------------------------------------------------------------}
+
+-- | Used only for 'Show'
+data UnknownOp where
+  UnknownOp :: Op r r' -> UnknownOp
+
+opsToList :: Ops r r' -> [UnknownOp]
+opsToList Done        = []
+opsToList (Op op ops) = UnknownOp op : opsToList ops
+
+instance Show UnknownOp     where show (UnknownOp x) = show x
+instance Show (SomeField r) where show (SomeField x) = show x
+instance Show (SomeOp    r) where show (SomeOp    x) = show x
+instance Show (SomeOps   r) where show (SomeOps   x) = show (opsToList x)
+
+{-------------------------------------------------------------------------------
+  Generation
+-------------------------------------------------------------------------------}
+
+-- | Known row
+--
+-- @large-anon@ is not designed for inductive reasoning, which makes
+-- constructing a random record iteratively rather difficult. We could use the
+-- (unsafe) low level API, but part of what we want to test here is the high
+-- level translation the library does in the plugin. We therefore restrict our
+-- attention to specific valid rows.
+--
+-- TODO: If we add allow for permutations, we can also test 'Anon.project'.
+data KnownRow :: Row Type -> Type where
+  Valid0 :: KnownRow '[]
+  Valid1 :: KnownRow '[ "f1" := Int ]
+  Valid2 :: KnownRow '[ "f2" := Int, "f1" := Int ]
+  Valid3 :: KnownRow '[ "f3" := Int, "f2" := Int, "f1" := Int ]
+
+class IsKnownRow (row :: Row Type) where
+  isKnownRow :: proxy row -> KnownRow row
+
+instance IsKnownRow '[]                                        where isKnownRow _ = Valid0
+instance IsKnownRow '[ "f1" := Int ]                           where isKnownRow _ = Valid1
+instance IsKnownRow '[ "f2" := Int, "f1" := Int ]              where isKnownRow _ = Valid2
+instance IsKnownRow '[ "f3" := Int, "f2" := Int, "f1" := Int ] where isKnownRow _ = Valid3
+
+
+
+tryPickExisting :: KnownRow r -> Maybe (Gen (SomeField r))
+tryPickExisting Valid0 = Nothing
+tryPickExisting Valid1 = Just $ elements [ SomeField #f1 ]
+tryPickExisting Valid2 = Just $ elements [ SomeField #f1
+                                         , SomeField #f2
+                                         ]
+tryPickExisting Valid3 = Just $ elements [ SomeField #f1
+                                         , SomeField #f2
+                                         , SomeField #f3
+                                         ]
+
+tryGenInsert :: KnownRow r -> Maybe (Int -> Gen (SomeOp r))
+tryGenInsert Valid0 = Just $ \v -> return $ SomeOp (Insert #f1 v)
+tryGenInsert Valid1 = Just $ \v -> return $ SomeOp (Insert #f2 v)
+tryGenInsert Valid2 = Just $ \v -> return $ SomeOp (Insert #f3 v)
+tryGenInsert Valid3 = Nothing
+
+genOp :: forall proxy r. IsKnownRow r => proxy r -> Gen (SomeOp r)
+genOp r = oneof . concat $ [
+      [ do SomeField field <- genField
+           return $ SomeOp (Get field)
+      | Just genField <- [tryPickExisting $ isKnownRow r]
+      ]
+    , [ do SomeField field <- genField
+           newValue <- choose (0, 100)
+           return $ SomeOp (Set field newValue)
+      | Just genField <- [tryPickExisting $ isKnownRow r]
+      ]
+    , [ do v <- choose (0, 100)
+           genInsert v
+      | Just genInsert <- [tryGenInsert (isKnownRow r)]
+      ]
+    , [ return $ SomeOp Apply ]
+    ]
+
+genOpsFrom :: IsKnownRow r => proxy r -> Int -> Gen (SomeOps r)
+genOpsFrom _ 0 = return $ SomeOps Done
+genOpsFrom r n = do SomeOp  op  <- genOp      r
+                    SomeOps ops <- genOpsFrom op (pred n)
+                    return $ SomeOps (Op op ops)
+
+genOps :: Gen (SomeOps '[])
+genOps = do
+    n <- choose (0, 10)
+    genOpsFrom Anon.empty n
+
+{-------------------------------------------------------------------------------
+  Shrinking
+
+  We could be much more sophisticated in how we shrink, but now for we just pick
+  the low hanging fruit only. Specifically, we do not try to omit/change any
+  instructions that affect types (specifically, inserts).
+-------------------------------------------------------------------------------}
+
+sameResultRow :: Op r r' -> Maybe (r :~: r')
+sameResultRow (Insert _ _) = Nothing
+sameResultRow (Get _)      = Just Refl
+sameResultRow (Set _ _)    = Just Refl
+sameResultRow Apply        = Just Refl
+
+isDone :: Ops r r' -> Bool
+isDone Done     = True
+isDone (Op _ _) = False
+
+shrinkOp :: Op r r' -> [Op r r']
+shrinkOp (Insert f n) = Insert f <$> shrink n
+shrinkOp (Get _)      = []
+shrinkOp (Set f n)    = Set f <$> shrink n
+shrinkOp Apply        = []
+
+shrinkOps :: IsKnownRow r' => Ops r r' -> [SomeOps r]
+shrinkOps Done        = []
+shrinkOps (Op op ops) = concat [
+      -- Shrink the operation
+      [ SomeOps $ Op op' ops
+      | op' <- shrinkOp op
+      ]
+
+      -- Shrink the tail
+    , [ SomeOps $ Op op ops'
+      | SomeOps ops' <- shrinkOps ops
+      ]
+
+      -- Drop the operation
+    , [ SomeOps $ ops
+      | Just Refl <- [sameResultRow op]
+      ]
+
+      -- Drop the tail
+    , [ SomeOps $ Op op Done
+      | not $ isDone ops
+      ]
+    ]
+
+{-------------------------------------------------------------------------------
+  Arbitrary instance
+-------------------------------------------------------------------------------}
+
+instance Arbitrary (SomeOps '[]) where
+  arbitrary            = genOps
+  shrink (SomeOps ops) = shrinkOps ops
+
+{-------------------------------------------------------------------------------
+  Top-level
+
+  These tests test the various ways to construct a record bit by bit, thereby
+  constructing a 'Diff' (and occassionally applying that 'Diff').
+-------------------------------------------------------------------------------}
+
+tests :: TestTree
+tests = testGroup "Test.Prop.Record.Diff" [
+      testProperty "diff" test_diff
+    ]
+
+test_diff :: SomeOps '[] -> Property
+test_diff (SomeOps ops) = execute ops === TestOk

--- a/large-anon/test/Test/Sanity/Merging.hs
+++ b/large-anon/test/Test/Sanity/Merging.hs
@@ -20,7 +20,6 @@ import qualified Data.Record.Anon.Advanced as Anon
 tests :: TestTree
 tests = testGroup "Test.Sanity.Merging" [
       testCase "concrete"     test_concrete
-    , testCase "polymorphic"  test_polymorphic
     , testCase "eqConstraint" test_eqConstraint
     ]
 
@@ -57,19 +56,6 @@ test_concrete :: Assertion
 test_concrete = do
     assertEqual "get" (I True) $ Anon.get #a ab
     assertEqual "set" ab'      $ Anon.set #a (I False) ab
-
-test_polymorphic :: Assertion
-test_polymorphic = do
-    assertEqual "get" (I 1) $ getPoly ab
-    assertEqual "set" ab'   $ setPoly ab
-  where
-    getPoly :: Record I (Merge [ "a" := Bool, "b" := Int ] r) -> I Int
-    getPoly = Anon.get #b
-
-    setPoly ::
-         Record I (Merge [ "a" := Bool, "b" := Int ] r)
-      -> Record I (Merge [ "a" := Bool, "b" := Int ] r)
-    setPoly = Anon.set #a (I False)
 
 -- | Test that type equalities are handled correctly
 test_eqConstraint :: Assertion

--- a/large-anon/test/Test/Sanity/Regression.hs
+++ b/large-anon/test/Test/Sanity/Regression.hs
@@ -1,0 +1,83 @@
+{-# OPTIONS_GHC -fplugin=Data.Record.Anon.Plugin #-}
+{-# LANGUAGE OverloadedLabels #-}
+
+module Test.Sanity.Regression (tests) where
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import Data.Record.Anon.Simple
+
+{-------------------------------------------------------------------------------
+  Top-level
+-------------------------------------------------------------------------------}
+
+-- | Sets for specific bugs
+tests :: TestTree
+tests = testGroup "Test.Sanity.Regression" [
+      testGroup "issue146" [
+          testCase "get_insert_anon"                      test_get_insert_anon
+        , testCase "get_insert_applyPending_insert_empty" test_get_insert_applyPending_insert_empty
+        , testCase "get_insert_insert_empty"              test_get_insert_insert_empty
+        , testCase "get_applyPending_insert_empty"        test_get_applyPending_insert_empty
+        , testCase "get_insert_empty"                     test_get_insert_empty
+        ]
+    ]
+
+{-------------------------------------------------------------------------------
+  Issue #146
+-------------------------------------------------------------------------------}
+
+-- | The issue as reported
+--
+-- The bug caused this test to segfault.
+test_get_insert_anon :: Assertion
+test_get_insert_anon =
+    assertEqual "" "field1" $
+        get #field1
+      $ insert #field2 "field2"
+      $ ANON { field1 = "field1" }
+
+-- | Manual expansion of ANON
+--
+-- The bug caused this test to segfault.
+test_get_insert_applyPending_insert_empty :: Assertion
+test_get_insert_applyPending_insert_empty =
+    assertEqual "" "field1" $
+        get #field1
+      $ insert #field2 "field2"
+      $ applyPending
+      $ insert #field1 "field1"
+      $ empty
+
+-- | Omit call to 'applyPending'
+--
+-- This test was not affected by the bug.
+test_get_insert_insert_empty :: Assertion
+test_get_insert_insert_empty =
+    assertEqual "" "field1" $
+        get #field1
+      $ insert #field2 "field2"
+      $ insert #field1 "field1"
+      $ empty
+
+-- | Only single insert, but still call applyPending
+--
+-- This test was not affected by the bug.
+test_get_applyPending_insert_empty :: Assertion
+test_get_applyPending_insert_empty =
+    assertEqual "" "field1" $
+        get #field1
+      $ applyPending
+      $ insert #field1 "field1"
+      $ empty
+
+-- | Simplest form: just a get after an insert
+--
+-- The bug caused this test to segfault.
+test_get_insert_empty :: Assertion
+test_get_insert_empty =
+    assertEqual "" "field1" $
+        get #field1
+      $ insert #field1 "field1"
+      $ empty

--- a/large-anon/test/Test/Sanity/Regression.hs
+++ b/large-anon/test/Test/Sanity/Regression.hs
@@ -1,5 +1,6 @@
-{-# OPTIONS_GHC -fplugin=Data.Record.Anon.Plugin #-}
 {-# LANGUAGE OverloadedLabels #-}
+
+{-# OPTIONS_GHC -fplugin=Data.Record.Anon.Plugin #-}
 
 module Test.Sanity.Regression (tests) where
 
@@ -74,7 +75,7 @@ test_get_applyPending_insert_empty =
 
 -- | Simplest form: just a get after an insert
 --
--- The bug caused this test to segfault.
+-- This test was not affected by the bug.
 test_get_insert_empty :: Assertion
 test_get_insert_empty =
     assertEqual "" "field1" $

--- a/large-anon/test/TestLargeAnon.hs
+++ b/large-anon/test/TestLargeAnon.hs
@@ -22,6 +22,7 @@ import qualified Test.Sanity.PolyKinds
 import qualified Test.Sanity.RebindableSyntax.Disabled
 import qualified Test.Sanity.RebindableSyntax.Enabled
 import qualified Test.Sanity.RecordLens
+import qualified Test.Sanity.Regression
 import qualified Test.Sanity.Simple
 import qualified Test.Sanity.SrcPlugin.WithoutTypelet
 import qualified Test.Sanity.SrcPlugin.WithTypelet
@@ -52,6 +53,7 @@ main = defaultMain $ testGroup "large-anon" [
         , Test.Sanity.RebindableSyntax.Enabled.tests
         , Test.Sanity.Fourmolu.OverloadedRecordDot.tests
         , Test.Sanity.Fourmolu.OverloadedRecordUpdate.tests
+        , Test.Sanity.Regression.tests
         ]
     , testGroup "Prop" [
           Test.Prop.Record.Combinators.Simple.tests

--- a/large-anon/test/TestLargeAnon.hs
+++ b/large-anon/test/TestLargeAnon.hs
@@ -4,6 +4,7 @@ import Test.Tasty
 
 import qualified Test.Prop.Record.Combinators.Constrained
 import qualified Test.Prop.Record.Combinators.Simple
+import qualified Test.Prop.Record.Diff
 import qualified Test.Sanity.AllFields
 import qualified Test.Sanity.Applicative
 import qualified Test.Sanity.BlogPost
@@ -56,7 +57,8 @@ main = defaultMain $ testGroup "large-anon" [
         , Test.Sanity.Regression.tests
         ]
     , testGroup "Prop" [
-          Test.Prop.Record.Combinators.Simple.tests
+          Test.Prop.Record.Diff.tests
+        , Test.Prop.Record.Combinators.Simple.tests
         , Test.Prop.Record.Combinators.Constrained.tests
         ]
     ]

--- a/large-generics/large-generics.cabal
+++ b/large-generics/large-generics.cabal
@@ -13,7 +13,7 @@ author:             Edsko de Vries
 maintainer:         edsko@well-typed.com
 category:           Generics
 extra-source-files: CHANGELOG.md
-tested-with:        GHC ==8.8.4 || ==8.10.7 || ==9.0.2 || ==9.2.7 || ==9.4.4
+tested-with:        GHC ==8.8.4 || ==8.10.7 || ==9.0.2 || ==9.2.8 || ==9.4.5
 
 library
   exposed-modules:

--- a/large-records/large-records.cabal
+++ b/large-records/large-records.cabal
@@ -16,7 +16,7 @@ author:             Edsko de Vries
 maintainer:         edsko@well-typed.com
 category:           Generics
 extra-source-files: CHANGELOG.md
-tested-with:        GHC ==8.8.4 || ==8.10.7 || ==9.0.2 || ==9.2.7 || ==9.4.4
+tested-with:        GHC ==8.8.4 || ==8.10.7 || ==9.0.2 || ==9.2.8 || ==9.4.5
 
 source-repository head
   type:     git

--- a/typelet/typelet.cabal
+++ b/typelet/typelet.cabal
@@ -17,7 +17,7 @@ maintainer:         edsko@well-typed.com
 copyright:          Well-Typed LLP, Juspay Technologies Pvt Ltd
 category:           Plugin
 extra-source-files: CHANGELOG.md
-tested-with:        GHC ==8.8.4 || ==8.10.7 || ==9.0.2 || ==9.2.7 || ==9.4.4
+tested-with:        GHC ==8.8.4 || ==8.10.7 || ==9.0.2 || ==9.2.8 || ==9.4.5
 
 source-repository head
   type:     git


### PR DESCRIPTION
This fixes #146. Most commits here are just preparatory: the actual fix is the semi-final "Reverse record order" commit. This also adds property tests that test the `Diff` operations more thoroughly (these property tests can reproduce the test case from #146 as a minimal counter-example).