### PR TITLE
Disable fourmolu flag

### DIFF
--- a/large-anon/CHANGELOG.md
+++ b/large-anon/CHANGELOG.md
@@ -17,6 +17,8 @@
   support did not extend to other constraints, it was probably not very useful
   anyway; `large-anon` is quite explicit about not supporting inductive
   reasoning.
+* Add `disableFourmoluExec` flag to disable the Fourmolu tests in the test suite
+  (#145; together with Johannes Gerer).
 
 ## 0.2.1 -- 2023-06-05
 

--- a/large-anon/large-anon.cabal
+++ b/large-anon/large-anon.cabal
@@ -190,9 +190,12 @@ test-suite test-large-anon
   -- if impl(ghc >= 8.10)
   --   ghc-options: -Wunused-packages
 
-  if impl(ghc >= 9.2)
+  if impl(ghc >= 9.2) && !flag(disableFourmoluExec)
     build-tool-depends:
       large-anon:large-anon-testsuite-fourmolu-preprocessor
+  else
+    cpp-options:
+      -DNO_FOURMOLU
 
 Executable large-anon-testsuite-fourmolu-preprocessor
   main-is:

--- a/large-anon/large-anon.cabal
+++ b/large-anon/large-anon.cabal
@@ -209,10 +209,15 @@ Executable large-anon-testsuite-fourmolu-preprocessor
       -Wall
 
   -- Fourmolu is only compatible with RDP syntax from ghc 9.2 and up.
-  if impl(ghc < 9.2)
+  if impl(ghc < 9.2) || flag(disableFourmoluExec)
     buildable: False
 
 Flag debug
   Description: Enable internal debugging features
+  Default: False
+  Manual: True
+
+Flag disableFourmoluExec
+  Description: Disable executable large-anon-testsuite-fourmolu-preprocessor
   Default: False
   Manual: True

--- a/large-anon/test/Test/Sanity/Fourmolu/OverloadedRecordDot.hs
+++ b/large-anon/test/Test/Sanity/Fourmolu/OverloadedRecordDot.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE CPP #-}
 
-#if __GLASGOW_HASKELL__ < 902
+#ifdef NO_FOURMOLU
 
 module Test.Sanity.Fourmolu.OverloadedRecordDot (tests) where
 
@@ -10,7 +10,7 @@ import Test.Tasty.HUnit
 tests :: TestTree
 tests =
     testCaseInfo "Test.Sanity.Fourmolu.OverloadedRecordDot" $
-      return "Skipped for ghc < 9.2"
+      return "Fourmolu tests disabled"
 
 #else
 

--- a/large-anon/test/Test/Sanity/Fourmolu/OverloadedRecordUpdate.hs
+++ b/large-anon/test/Test/Sanity/Fourmolu/OverloadedRecordUpdate.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE CPP #-}
 
-#if __GLASGOW_HASKELL__ < 902
+#ifdef NO_FOURMOLU
 
 module Test.Sanity.Fourmolu.OverloadedRecordUpdate (tests) where
 
@@ -10,7 +10,7 @@ import Test.Tasty.HUnit
 tests :: TestTree
 tests =
     testCaseInfo "Test.Sanity.Fourmolu.OverloadedRecordUpdate" $
-      return "Skipped for ghc < 9.2"
+      return "Fourmolu tests disabled"
 
 #else
 


### PR DESCRIPTION
This extends #145 with a bit of logic to make sure the test suite still runs when the flag is used.