### PR TITLE
Bump dependency primitive to >= 0.8 && < 0.9

### DIFF
--- a/large-anon/large-anon.cabal
+++ b/large-anon/large-anon.cabal
@@ -78,7 +78,7 @@ library
     , hashable         >= 1.3   && < 1.5
     , mtl              >= 2.2.1 && < 2.3
     , optics-core      >= 0.3   && < 0.5
-    , primitive        >= 0.7.1 && < 0.8
+    , primitive        >= 0.8   && < 0.9
     , record-hasfield  >= 1.0   && < 1.1
     , sop-core         >= 0.5   && < 0.6
     , syb              >= 0.7   && < 0.8

--- a/large-generics/large-generics.cabal
+++ b/large-generics/large-generics.cabal
@@ -47,7 +47,7 @@ library
     , deepseq      >= 1.4.4 && < 1.5
     , generics-sop >= 0.5   && < 0.6
     , sop-core     >= 0.5   && < 0.6
-    , primitive    >= 0.7   && < 0.8
+    , primitive    >= 0.8   && < 0.9
 
   if impl(ghc >= 8.10)
     ghc-options: -Wunused-packages

--- a/large-records/large-records.cabal
+++ b/large-records/large-records.cabal
@@ -47,7 +47,7 @@ library
       base            >= 4.13   && < 4.18
     , containers      >= 0.6.2  && < 0.7
     , mtl             >= 2.2.1  && < 2.3
-    , primitive       >= 0.7    && < 0.8
+    , primitive       >= 0.8    && < 0.9
     , syb             >= 0.7    && < 0.8
     , record-hasfield >= 1.0    && < 1.1
 


### PR DESCRIPTION
So that the libraries large-anon, large-generics, and large-records compile with the current latest primitive (0.8).

This dependency bump is safe, because:
- the libraries compile after bumping primitive to >= 0.8 && < 0.9,
- the changes in primitive 0.8.0.0 do not affect the libraries:
  - the changes are mostly adding new APIs and modules, and
  - the only breaking change is on PrimArray, which is not used in the libraries.