### PR TITLE
Idempotence & version bounds tweak

### DIFF
--- a/large-generics/large-generics.cabal
+++ b/large-generics/large-generics.cabal
@@ -47,7 +47,7 @@ library
     , deepseq      >= 1.4.4 && < 1.6
     , generics-sop >= 0.5   && < 0.6
     , sop-core     >= 0.5   && < 0.6
-    , primitive    >= 0.8   && < 0.10
+    , primitive    >= 0.7.3 && < 0.10
 
   if impl(ghc >= 8.10)
     ghc-options: -Wunused-packages

--- a/large-records/large-records.cabal
+++ b/large-records/large-records.cabal
@@ -48,7 +48,7 @@ library
     , containers       >= 0.6.2  && < 0.8
     , ghc              >= 8.10   && < 9.7
     , mtl              >= 2.2.1  && < 2.4
-    , primitive        >= 0.8    && < 0.10
+    , primitive        >= 0.7.3  && < 0.10
     , record-hasfield  >= 1.0    && < 1.1
     , syb              >= 0.7    && < 0.8
     , template-haskell >= 2.16   && < 2.21


### PR DESCRIPTION
`large-records` has been really helpful. We have a fairly big `beam` schema, and when combined with [`beam-automigrate`](https://hackage.haskell.org/package/beam-automigrate) compilation ran out of memory on an 8GB system. With a `large-records` schema, the peak memory usage during compilation is ~2.5GB.

## Plugin idempotence

When I used `large-records` in GHCi[^1] I found that the plugin fired twice, feeding the output from the first run into the second run. I got an error, because the output of the first run is an invalid `large-records` declaration. This change removes the annotation when the `large-records` declaration is processed, so that subsequent runs don't try to transform already-transformed datatypes.

## `primitive` version bounds

We're stuck with an older version of `primitive`, and `large-records` seems to work with it.

[^1]: We're using [Obelisk](https://github.com/obsidiansystems/obelisk) to launch GHCi. I noticed that Obelisk uses a syntax preprocessor (`-pgmF`); I wonder if that has something to do with it.