### PR TITLE
Full ghc 9.8 support

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -32,9 +32,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.8.2
+          - compiler: ghc-9.8.4
             compilerKind: ghc
-            compilerVersion: 9.8.2
+            compilerVersion: 9.8.4
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.6.6

--- a/beam-large-records/beam-large-records.cabal
+++ b/beam-large-records/beam-large-records.cabal
@@ -36,12 +36,12 @@ library
   build-depends:
       -- lower bound on beam-core is necessary
       -- see https://github.com/haskell-beam/beam/issues/585
-      base           >= 4.14     && < 4.19
+      base           >= 4.14     && < 4.20
     , beam-core      >= 0.10.3.0 && < 0.11
     , large-generics >= 0.2      && < 0.3
     , microlens      >= 0.4      && < 0.5
     , sop-core       >= 0.5      && < 0.6
-    , text           >= 1.2      && < 2.1
+    , text           >= 1.2      && < 2.2
   hs-source-dirs:
       src
   default-language:

--- a/large-anon/large-anon.cabal
+++ b/large-anon/large-anon.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               large-anon
-version:            0.3.2
+version:            0.3.2.1
 synopsis:           Scalable anonymous records
 description:        The @large-anon@ package provides support for anonymous
                     records in Haskell, with a focus on compile-time (and
@@ -74,12 +74,12 @@ library
 
   build-depends:
     , aeson            >= 1.4.4 && < 2.3
-    , base             >= 4.14  && < 4.19
-    , containers       >= 0.6.2 && < 0.8
+    , base             >= 4.14  && < 4.20
+    , containers       >= 0.6.2 && < 0.9
     , deepseq          >= 1.4.4 && < 1.6
-    , ghc              >= 8.10  && < 9.7
+    , ghc              >= 8.10  && < 9.11
     , ghc-tcplugin-api >= 0.14  && < 0.15
-    , hashable         >= 1.3   && < 1.5
+    , hashable         >= 1.3   && < 1.6
     , mtl              >= 2.2.1 && < 2.4
     , optics-core      >= 0.3   && < 0.5
     , primitive        >= 0.8   && < 0.10
@@ -204,9 +204,9 @@ Executable large-anon-testsuite-fourmolu-preprocessor
   hs-source-dirs:
       fourmolu-preprocessor
   build-depends:
-    , base     >= 4.16   && < 4.19
-    , fourmolu >= 0.10.1 && < 0.16
-    , text     >= 1.2    && < 2.1
+    , base     >= 4.16   && < 4.20
+    , fourmolu >= 0.10.1 && < 0.19
+    , text     >= 1.2    && < 2.2
   default-language:
       Haskell2010
   ghc-options:

--- a/large-anon/src/Data/Record/Anon/Internal/Plugin/Source/GhcShim.hs
+++ b/large-anon/src/Data/Record/Anon/Internal/Plugin/Source/GhcShim.hs
@@ -272,7 +272,7 @@ issueWarning l errMsg = do
 
     let msg :: Err.DiagnosticMessage
         msg = mkPlainError [] errMsg
-#else
+#elif __GLASGOW_HASKELL__ < 908
     let printOrThrow :: Err.Messages GhcMessage -> IO ()
         printOrThrow = printOrThrowDiagnostics
                          logger
@@ -281,6 +281,16 @@ issueWarning l errMsg = do
 
     let msg :: Err.UnknownDiagnostic
         msg = Err.UnknownDiagnostic $
+                mkPlainError [] errMsg
+#else
+    let printOrThrow :: Err.Messages GhcMessage -> IO ()
+        printOrThrow = printOrThrowDiagnostics
+                         logger
+                         (initPrintConfig dynFlags)
+                         (initDiagOpts dynFlags)
+
+    let msg :: Err.UnknownDiagnostic opts
+        msg = Err.mkSimpleUnknownDiagnostic $
                 mkPlainError [] errMsg
 #endif
     liftIO $ printOrThrow . Err.mkMessages . bag $

--- a/large-anon/src/Data/Record/Anon/Internal/Plugin/TC/GhcTcPluginAPI.hs
+++ b/large-anon/src/Data/Record/Anon/Internal/Plugin/TC/GhcTcPluginAPI.hs
@@ -45,7 +45,9 @@ import Constraint (Ct(..))
 import GHC.Tc.Types.Constraint (Ct(..))
 #endif
 
-#if __GLASGOW_HASKELL__ >= 902
+#if __GLASGOW_HASKELL__ >= 908
+import GHC.Tc.Types.Constraint (Ct(..), CanEqLHS(..), EqCt(..))
+#elif __GLASGOW_HASKELL__ >= 902
 import GHC.Tc.Types.Constraint (Ct(..), CanEqLHS(..))
 #endif
 
@@ -56,7 +58,17 @@ isCanonicalVarEq = \case
     CFunEqCan{..} -> Just (cc_fsk, mkTyConApp cc_fun cc_tyargs)
     _otherwise    -> Nothing
 #endif
-#if __GLASGOW_HASKELL__ >= 902
+#if __GLASGOW_HASKELL__ >= 908
+isCanonicalVarEq = \case
+    CEqCan (EqCt {..})
+      | TyVarLHS var <- eq_lhs
+      -> Just (var, eq_rhs)
+      | TyFamLHS tyCon args <- eq_lhs
+      , Just var            <- getTyVar_maybe eq_rhs
+      -> Just (var, mkTyConApp tyCon args)
+    _otherwise
+      -> Nothing
+#elif __GLASGOW_HASKELL__ >= 902
 isCanonicalVarEq = \case
     CEqCan{..}
       | TyVarLHS var <- cc_lhs

--- a/large-generics/large-generics.cabal
+++ b/large-generics/large-generics.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               large-generics
-version:            0.2.2
+version:            0.2.2.1
 synopsis:           Generic programming API for large-records and large-anon
 description:        The large-generics package offers a style of generic
                     programming inspired by generics-sop, but optimized for

--- a/large-records-benchmarks/large-records-benchmarks.cabal
+++ b/large-records-benchmarks/large-records-benchmarks.cabal
@@ -21,7 +21,7 @@ common defaults
   default-language:
       Haskell2010
   build-depends:
-      base >= 4.14 && < 4.19
+      base >= 4.14 && < 4.20
   ghc-options:
       -Wall
 

--- a/large-records/large-records.cabal
+++ b/large-records/large-records.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               large-records
-version:            0.4.2
+version:            0.4.2.1
 synopsis:           Efficient compilation for large records, linear in the size of the record
 description:        For many reasons, the internal code generated for modules
                     that contain records is quadratic in the number of record
@@ -20,6 +20,7 @@ tested-with:        GHC ==8.10.7
                     GHC ==9.2.8
                     GHC ==9.4.8
                     GHC ==9.6.6
+                    GHC ==9.8.4
 
 source-repository head
   type:     git
@@ -47,14 +48,14 @@ library
       Data.Record.Internal.Plugin.Record
 
   build-depends:
-    , base             >= 4.14   && < 4.19
-    , containers       >= 0.6.2  && < 0.8
-    , ghc              >= 8.10   && < 9.7
+    , base             >= 4.14   && < 4.20
+    , containers       >= 0.6.2  && < 0.9
+    , ghc              >= 8.10   && < 9.9
     , mtl              >= 2.2.1  && < 2.4
     , primitive        >= 0.7.3  && < 0.10
     , record-hasfield  >= 1.0    && < 1.1
     , syb              >= 0.7    && < 0.8
-    , template-haskell >= 2.16   && < 2.21
+    , template-haskell >= 2.16   && < 2.22
 
       -- large-generics 0.2 starts using 'SmallArray' instead of 'Vector'
     , large-generics >= 0.2 && < 0.3

--- a/large-records/src/Data/Record/Internal/GHC/TemplateHaskellStyle.hs
+++ b/large-records/src/Data/Record/Internal/GHC/TemplateHaskellStyle.hs
@@ -241,6 +241,10 @@ recConE = \recName -> mkRec recName . map (uncurry mkFld)
 recUpdE :: LHsExpr GhcPs -> [(LRdrName, LHsExpr GhcPs)] -> LHsExpr GhcPs
 recUpdE = \recExpr -> updRec recExpr . map (uncurry updFld)
   where
+#if __GLASGOW_HASKELL__ >= 908
+    updRec :: LHsExpr GhcPs -> [LHsRecUpdField GhcPs GhcPs] -> LHsExpr GhcPs
+    updRec expr fields = inheritLoc expr $ RecordUpd defExt expr $ RegularRecUpdFields noExtField fields
+#else
     updRec :: LHsExpr GhcPs -> [LHsRecUpdField GhcPs] -> LHsExpr GhcPs
     updRec expr fields = inheritLoc expr $
         RecordUpd defExt expr
@@ -248,8 +252,13 @@ recUpdE = \recExpr -> updRec recExpr . map (uncurry updFld)
           $ Left
 #endif
             fields
+#endif
 
+#if __GLASGOW_HASKELL__ >= 908
+    updFld :: LRdrName -> LHsExpr GhcPs -> LHsRecUpdField GhcPs GhcPs
+#else
     updFld :: LRdrName -> LHsExpr GhcPs -> LHsRecUpdField GhcPs
+#endif
     updFld name val = inheritLoc name $
 #if __GLASGOW_HASKELL__ >= 904
         HsFieldBind

--- a/large-records/src/Data/Record/Internal/Plugin/CodeGen.hs
+++ b/large-records/src/Data/Record/Internal/Plugin/CodeGen.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                 #-}
 {-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -15,10 +16,15 @@ import Language.Haskell.TH (Extension(StrictData))
 import qualified Data.Generics as SYB
 
 import Data.Record.Internal.GHC.Fresh
-import Data.Record.Internal.GHC.Shim hiding (mkTyVar)
 import Data.Record.Internal.GHC.TemplateHaskellStyle
 import Data.Record.Internal.Plugin.Names
 import Data.Record.Internal.Plugin.Record
+
+#if __GLASGOW_HASKELL__ >= 908
+import Data.Record.Internal.GHC.Shim hiding (fieldName, mkTyVar)
+#else
+import Data.Record.Internal.GHC.Shim hiding (mkTyVar)
+#endif
 
 {-------------------------------------------------------------------------------
   Top-level

--- a/typelet/typelet.cabal
+++ b/typelet/typelet.cabal
@@ -1,7 +1,7 @@
 cabal-version:      2.4
 build-type:         Simple
 name:               typelet
-version:            0.1.5
+version:            0.1.5.1
 synopsis:           Plugin to faciliate type-level let
 description:        For a certain class of programs, type-level let is essential
                     in order to be able to write these programs in such a way
@@ -39,8 +39,8 @@ library
         TypeLet.Plugin.Substitution
     build-depends:
       , base             >= 4.14 && < 4.20
-      , containers       >= 0.6  && < 0.7
-      , ghc              >= 8.10 && < 9.9
+      , containers       >= 0.6  && < 0.9
+      , ghc              >= 8.10 && < 9.10
       , ghc-tcplugin-api >= 0.14 && < 0.15
     hs-source-dirs:
         src


### PR DESCRIPTION
This pull request updates all libraries to be compatible with GHC 9.8. This involved updating dependencies and addressing changes in the GHC API. All tests are passing.

While the majority of the changes were straightforward, verification of two points by someone more familiar with the GHC API would be helpful:

1. **`HsTyVarBndr` and `HsBndrVis`:** GHC 9.8 introduced a `HsBndrVis` flag to `HsTyVarBndr`.  I've defaulted this to `HsBndrRequired` in  [`large-records/src/Data/Record/Internal/GHC/Shim.hs` on line 400](https://github.com/gbrsales/large-records/blob/7c47835b5169cf12200138b8708152da59eea4fc/large-records/src/Data/Record/Internal/GHC/Shim.hs#L400).  I'm unsure if this is the most appropriate default.

2. **`GHC.Types.Basic.Origin` and Pattern Matching Checks:** GHC 9.8 now requires an explicit annotation for whether to run pattern-match checks in generated code for `GHC.Types.Basic.Origin`. I've set this to `DoPmc` in [`src/Data/Record/Internal/GHC/Shim.hs` on line 363](https://github.com/gbrsales/large-records/blob/7c47835b5169cf12200138b8708152da59eea4fc/large-records/src/Data/Record/Internal/GHC/Shim.hs#L363). Maybe `SkipPmc` would make compilation time shorter?
