### PR TITLE
Bump version number on beam-large-records

### DIFF
--- a/beam-large-records/CHANGELOG.md
+++ b/beam-large-records/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Revision history for beam-large-records
 
+## 0.1.2 -- 2025-07-19
+
+* Relax bounds (Gabriele Sales)
+* Drop unused dependencies
+
 ## 0.1.1 -- 2025-03-11
 
 * First released version

--- a/beam-large-records/beam-large-records.cabal
+++ b/beam-large-records/beam-large-records.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               beam-large-records
-version:            0.1.1
+version:            0.1.2
 synopsis:           Integration of large-records with beam-core.
 description:        This package provides the necessary instances that make
                     it possible to use records defined with large-records as


### PR DESCRIPTION
I thought I could just do a Hackage revision, but turns out that's not possible when you drop dependencies.