### PR TITLE
Use LIdP GhcPs instead of LRdrName

### DIFF
--- a/large-records/src/Data/Record/Internal/GHC/Fresh.hs
+++ b/large-records/src/Data/Record/Internal/GHC/Fresh.hs
@@ -18,12 +18,12 @@ class Monad m => MonadFresh m where
   -- * These names should be used for module exports.
   -- * These names should be used for exactly /one/ binder.
   -- * The resulting name has the same 'NameSpace' as the argument.
-  freshName :: LRdrName -> m LRdrName
+  freshName :: ToSrcSpan l => GenLocated l RdrName -> m (GenLocated l RdrName)
   freshName = freshName' True
 
   -- variant which doesn't rename the variable.
   -- The 'False' variant can be used in types.
-  freshName' :: Bool -> LRdrName -> m LRdrName
+  freshName' :: ToSrcSpan l => Bool -> GenLocated l RdrName -> m (GenLocated l RdrName)
 
 newtype Fresh a = WrapFresh { unwrapFresh :: ReaderT NameCacheIO IO a }
   deriving newtype (Functor, Applicative, Monad)
@@ -32,7 +32,7 @@ instance MonadFresh Fresh where
   freshName' pfx (L l name) = WrapFresh $ ReaderT $ \nc -> do
       newUniq <- takeUniqFromNameCacheIO nc
       return $ L l $ Exact $
-        mkInternalName newUniq (newOccName (rdrNameOcc name)) l
+        mkInternalName newUniq (newOccName (rdrNameOcc name)) (toSrcSpan l)
     where
       -- Even when we generate fresh names, ghc can still complain about name
       -- shadowing, because this check only considers the 'OccName', not the

--- a/large-records/src/Data/Record/Internal/Plugin/Names.hs
+++ b/large-records/src/Data/Record/Internal/Plugin/Names.hs
@@ -19,81 +19,81 @@ data QualifiedNames = QualifiedNames {
       -- Prelude type classes
       --
 
-      prelude_type_Eq   :: LRdrName
-    , prelude_type_Ord  :: LRdrName
-    , prelude_type_Show :: LRdrName
-    , prelude_compare   :: LRdrName
-    , prelude_eq        :: LRdrName
-    , prelude_showsPrec :: LRdrName
+      prelude_type_Eq   :: LIdP GhcPs
+    , prelude_type_Ord  :: LIdP GhcPs
+    , prelude_type_Show :: LIdP GhcPs
+    , prelude_compare   :: LIdP GhcPs
+    , prelude_eq        :: LIdP GhcPs
+    , prelude_showsPrec :: LIdP GhcPs
 
       --
       -- Other base
       --
 
-    , type_Constraint  :: LRdrName
-    , type_GHC_Generic :: LRdrName
-    , type_GHC_Rep     :: LRdrName
-    , type_Int         :: LRdrName
-    , type_Proxy       :: LRdrName
-    , type_Type        :: LRdrName
-    , error            :: LRdrName
-    , ghc_from         :: LRdrName
-    , ghc_to           :: LRdrName
-    , proxy            :: LRdrName
+    , type_Constraint  :: LIdP GhcPs
+    , type_GHC_Generic :: LIdP GhcPs
+    , type_GHC_Rep     :: LIdP GhcPs
+    , type_Int         :: LIdP GhcPs
+    , type_Proxy       :: LIdP GhcPs
+    , type_Type        :: LIdP GhcPs
+    , error            :: LIdP GhcPs
+    , ghc_from         :: LIdP GhcPs
+    , ghc_to           :: LIdP GhcPs
+    , proxy            :: LIdP GhcPs
 
       --
       -- AnyArray
       --
 
-    , type_AnyArray    :: LRdrName
-    , anyArrayFromList :: LRdrName
-    , anyArrayToList   :: LRdrName
-    , anyArrayIndex    :: LRdrName
-    , anyArrayUpdate   :: LRdrName
+    , type_AnyArray    :: LIdP GhcPs
+    , anyArrayFromList :: LIdP GhcPs
+    , anyArrayToList   :: LIdP GhcPs
+    , anyArrayIndex    :: LIdP GhcPs
+    , anyArrayUpdate   :: LIdP GhcPs
 
       --
       -- large-generics
       --
 
-    , type_LR_Generic     :: LRdrName
-    , type_LR_MetadataOf  :: LRdrName
-    , type_LR_Constraints :: LRdrName
-    , lr_from             :: LRdrName
-    , lr_to               :: LRdrName
-    , lr_dict             :: LRdrName
-    , lr_metadata         :: LRdrName
+    , type_LR_Generic     :: LIdP GhcPs
+    , type_LR_MetadataOf  :: LIdP GhcPs
+    , type_LR_Constraints :: LIdP GhcPs
+    , lr_from             :: LIdP GhcPs
+    , lr_to               :: LIdP GhcPs
+    , lr_dict             :: LIdP GhcPs
+    , lr_metadata         :: LIdP GhcPs
 
       -- .. wrappers
 
-    , type_Rep         :: LRdrName
-    , type_Dict        :: LRdrName
-    , gcompare         :: LRdrName
-    , geq              :: LRdrName
-    , gshowsPrec       :: LRdrName
-    , noInlineUnsafeCo :: LRdrName
+    , type_Rep         :: LIdP GhcPs
+    , type_Dict        :: LIdP GhcPs
+    , gcompare         :: LIdP GhcPs
+    , geq              :: LIdP GhcPs
+    , gshowsPrec       :: LIdP GhcPs
+    , noInlineUnsafeCo :: LIdP GhcPs
 
       -- .. utilities
 
-    , anyArrayToRep   :: LRdrName
-    , anyArrayFromRep :: LRdrName
-    , mkDicts         :: LRdrName
-    , mkDict          :: LRdrName
-    , mkStrictField   :: LRdrName
-    , mkLazyField     :: LRdrName
-    , mkMetadata      :: LRdrName
+    , anyArrayToRep   :: LIdP GhcPs
+    , anyArrayFromRep :: LIdP GhcPs
+    , mkDicts         :: LIdP GhcPs
+    , mkDict          :: LIdP GhcPs
+    , mkStrictField   :: LIdP GhcPs
+    , mkLazyField     :: LIdP GhcPs
+    , mkMetadata      :: LIdP GhcPs
 
       -- .. ThroughLRGenerics
 
-    , type_ThroughLRGenerics  :: LRdrName
-    , wrapThroughLRGenerics   :: LRdrName
-    , unwrapThroughLRGenerics :: LRdrName
+    , type_ThroughLRGenerics  :: LIdP GhcPs
+    , wrapThroughLRGenerics   :: LIdP GhcPs
+    , unwrapThroughLRGenerics :: LIdP GhcPs
 
       --
       -- record-hasfield
       --
 
-    , type_HasField :: LRdrName
-    , hasField      :: LRdrName
+    , type_HasField :: LIdP GhcPs
+    , hasField      :: LIdP GhcPs
     }
 
 -- | Resolve qualified names
@@ -197,8 +197,8 @@ getQualifiedNames = do
     return QualifiedNames{..}
 
   where
-   exact :: Name -> LRdrName
-   exact = noLoc . Exact
+   exact :: Name -> LIdP GhcPs
+   exact = noLocA . Exact
 
    ghcClasses, ghcShow :: ModuleName
    ghcClasses = mkModuleName "GHC.Classes"

--- a/large-records/src/Data/Record/Internal/Plugin/Options.hs
+++ b/large-records/src/Data/Record/Internal/Plugin/Options.hs
@@ -82,7 +82,7 @@ getLargeRecordOptions =
 viewAnnotation :: AnnDecl GhcPs -> Maybe (String, (SrcSpan, LargeRecordOptions))
 viewAnnotation = \case
     PragAnnD (TypeAnnotation tyName) (intOptions -> Just options) ->
-      Just (nameBase tyName, (getLoc tyName, options))
+      Just (nameBase tyName, (toSrcSpan tyName, options))
     _otherwise ->
       Nothing
 
@@ -107,7 +107,7 @@ intOptions _ =
     Nothing
 
 intUpdate ::
-     (LRdrName, LHsExpr GhcPs)
+     (LIdP GhcPs, LHsExpr GhcPs)
   -> Maybe (LargeRecordOptions -> LargeRecordOptions)
 intUpdate (nameBase -> "debugLargeRecords", intBool -> Just b) =
     Just $ \opts -> opts { debugLargeRecords = b }

--- a/large-records/src/Data/Record/Internal/Plugin/Record.hs
+++ b/large-records/src/Data/Record/Internal/Plugin/Record.hs
@@ -29,9 +29,9 @@ import Data.Record.Internal.Plugin.Options (LargeRecordOptions)
 
 -- | A representation for records that can be processed by large-records.
 data Record = Record {
-      recordTyName    :: LRdrName
+      recordTyName    :: LIdP GhcPs
     , recordTyVars    :: [LHsTyVarBndr GhcPs]
-    , recordConName   :: LRdrName
+    , recordConName   :: LIdP GhcPs
     , recordFields    :: [Field]
     , recordDerivings :: [RecordDeriving]
     , recordOptions   :: LargeRecordOptions
@@ -43,7 +43,7 @@ data Record = Record {
     }
 
 data Field = Field {
-      fieldName       :: LRdrName
+      fieldName       :: LIdP GhcPs
     , fieldType       :: LHsType GhcPs
     , fieldStrictness :: HsSrcBang
     , fieldIndex      :: Int
@@ -98,7 +98,7 @@ viewRecord annLoc options decl =
 
 viewField ::
      MonadError Exception m
-  => (LRdrName, LHsType GhcPs) -> m (Int -> Field)  
+  => (LIdP GhcPs, LHsType GhcPs) -> m (Int -> Field)  
 viewField (name, typ) =
   return $ Field name (parensT (getBangType typ)) (getBangStrictness typ)
 


### PR DESCRIPTION
A lot less of `reLoc/A`, which will helpfully help adding support for GHC-9.10+ (which removed these helpers)