### PR TITLE
Separate HsSrcBang out of field type

### DIFF
--- a/large-records/src/Data/Record/Internal/Plugin/CodeGen.hs
+++ b/large-records/src/Data/Record/Internal/Plugin/CodeGen.hs
@@ -124,19 +124,11 @@ genDatatype Record{..} = pure $
         | (i, _) <- zip [1 :: Int ..] recordFields
         ]
 
-    optionalBang :: HsSrcBang -> LHsType GhcPs -> LHsType GhcPs
-    optionalBang bang = noLocA . HsBangTy defExt
-#if __GLASGOW_HASKELL__ >= 912
-      (case bang of HsSrcBang _ b -> b)
-#else
-      bang
-#endif
-
     fieldContext :: LIdP GhcPs -> Field -> LHsType GhcPs
     fieldContext var fld = equalP (VarT var) (fieldType fld)
 
-    fieldExistentialType :: LIdP GhcPs -> Field -> (LIdP GhcPs, LHsType GhcPs)
-    fieldExistentialType var fld = (fieldName fld, optionalBang (fieldStrictness fld) $ VarT var)
+    fieldExistentialType :: LIdP GhcPs -> Field -> (LIdP GhcPs, LHsType GhcPs, HsSrcBang)
+    fieldExistentialType var fld = (fieldName fld, VarT var, fieldStrictness fld)
 
 -- | Generate conversion to and from an array
 --

--- a/large-records/src/Data/Record/Internal/Plugin/Record.hs
+++ b/large-records/src/Data/Record/Internal/Plugin/Record.hs
@@ -98,9 +98,9 @@ viewRecord annLoc options decl =
 
 viewField ::
      MonadError Exception m
-  => (LIdP GhcPs, LHsType GhcPs) -> m (Int -> Field)
-viewField (name, typ) =
-  return $ Field name (parensT (getBangType typ)) (getBangStrictness typ)
+  => (LIdP GhcPs, LHsType GhcPs, HsSrcBang) -> m (Int -> Field)
+viewField (name, typ, bang) =
+  return $ Field name (parensT typ) bang
 
 viewRecordDerivings ::
      MonadError Exception m


### PR DESCRIPTION
The main motivation is that GHC-9.14 forces us to things this way. And even if it didn't, this makes sense.
"Bangs" are not part of the type, they are part of the field declaration, and once we already keep them separate (e.g. in Field), it's good to simply never mix them.